### PR TITLE
fix: Add non-JSON and empty error bodies handling

### DIFF
--- a/open_api_client_build/build_client.py
+++ b/open_api_client_build/build_client.py
@@ -113,6 +113,38 @@ def get_and_fix_spec(src: str, path: str | os.PathLike):
     return spec
 
 
+def fix_nonjson_errors(api_path: pathlib.Path) -> None:
+    """Wrap Errors.from_dict(response.json()) calls in try/except.
+
+    The generated _parse_response functions call response.json() unconditionally
+    for every error status code. When Polarion returns an HTML error page or an
+    empty body, this raises json.decoder.JSONDecodeError instead of a proper
+    PolarionApiException. Wrapping in try/except lets _raise_on_error emit a
+    PolarionApiUnexpectedException instead.
+    """
+    pattern = re.compile(
+        r"^( +)(response_\w+ = Errors\.from_dict\(response\.json\(\)\))",
+        re.MULTILINE,
+    )
+
+    def _replace(m: re.Match) -> str:
+        indent = m.group(1)
+        stmt = m.group(2)
+        var_name = stmt.split(" =")[0].strip()
+        return (
+            f"{indent}try:\n"
+            f"{indent}    {stmt}\n"
+            f"{indent}except Exception:\n"
+            f"{indent}    {var_name} = None"
+        )
+
+    for path in api_path.rglob("*.py"):
+        original = path.read_text(encoding="utf-8")
+        fixed = pattern.sub(_replace, original)
+        if fixed != original:
+            path.write_text(fixed, encoding="utf-8")
+
+
 def generate_client(spec):
     with tempfile.NamedTemporaryFile("w", delete=False) as f:
         json.dump(spec, f)
@@ -140,6 +172,7 @@ def generate_client(spec):
             cwd=rest_api_path,
             check=True,
         )
+    fix_nonjson_errors(output_path / "api")
     subprocess.run(["git", "add", output_path], check=True, cwd=rest_api_path)
     p = subprocess.run(
         ["pre-commit", "run", "-a"], cwd=rest_api_path, check=False

--- a/polarion_rest_api_client/open_api_client/api/collections/close_collection.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/close_collection.py
@@ -31,39 +31,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/delete_collection.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/delete_collection.py
@@ -31,31 +31,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/delete_collections.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/delete_collections.py
@@ -42,39 +42,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/delete_collections_relationship.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/delete_collections_relationship.py
@@ -44,43 +44,73 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 405:
-        response_405 = Errors.from_dict(response.json())
+        try:
+            response_405 = Errors.from_dict(response.json())
+        except Exception:
+            response_405 = None
 
         return response_405
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/get_collection.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/get_collection.py
@@ -57,31 +57,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/get_collections.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/get_collections.py
@@ -66,31 +66,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/get_collections_relationship.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/get_collections_relationship.py
@@ -99,31 +99,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/patch_collections.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/patch_collections.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/patch_collections_relationships.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/patch_collections_relationships.py
@@ -53,39 +53,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/post_collections.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/post_collections.py
@@ -44,43 +44,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/post_collections_relationships.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/post_collections_relationships.py
@@ -53,43 +53,73 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 405:
-        response_405 = Errors.from_dict(response.json())
+        try:
+            response_405 = Errors.from_dict(response.json())
+        except Exception:
+            response_405 = None
 
         return response_405
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/collections/reopen_collection.py
+++ b/polarion_rest_api_client/open_api_client/api/collections/reopen_collection.py
@@ -31,39 +31,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachment.py
@@ -61,31 +61,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachment_content.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachment_content.py
@@ -44,31 +44,52 @@ def _parse_response(
         response_200 = cast(Any, None)
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachments.py
@@ -66,31 +66,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/patch_document_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/patch_document_attachment.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/post_document_item_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/post_document_item_attachments.py
@@ -48,43 +48,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_comments/get_document_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/document_comments/get_document_comment.py
@@ -61,31 +61,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_comments/get_document_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/document_comments/get_document_comments.py
@@ -66,31 +66,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_comments/patch_document_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/document_comments/patch_document_comment.py
@@ -45,39 +45,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_comments/post_document_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/document_comments/post_document_comments.py
@@ -50,43 +50,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_parts/get_document_part.py
+++ b/polarion_rest_api_client/open_api_client/api/document_parts/get_document_part.py
@@ -61,31 +61,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_parts/get_document_parts.py
+++ b/polarion_rest_api_client/open_api_client/api/document_parts/get_document_parts.py
@@ -64,31 +64,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/document_parts/post_document_parts.py
+++ b/polarion_rest_api_client/open_api_client/api/document_parts/post_document_parts.py
@@ -48,43 +48,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/branch_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/branch_document.py
@@ -56,43 +56,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/branch_documents.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/branch_documents.py
@@ -41,31 +41,52 @@ def _parse_response(
 
         return response_202
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/copy_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/copy_document.py
@@ -56,43 +56,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/get_available_enum_options_for_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/get_available_enum_options_for_document.py
@@ -51,31 +51,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/get_available_enum_options_for_document_type.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/get_available_enum_options_for_document_type.py
@@ -52,31 +52,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/get_current_enumeration_options_for_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/get_current_enumeration_options_for_document.py
@@ -54,31 +54,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/get_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/get_document.py
@@ -56,31 +56,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/merge_document_from_master.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/merge_document_from_master.py
@@ -44,43 +44,73 @@ def _parse_response(
 
         return response_202
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/merge_document_to_master.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/merge_document_to_master.py
@@ -44,43 +44,73 @@ def _parse_response(
 
         return response_202
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/patch_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/patch_document.py
@@ -54,39 +54,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/documents/post_documents.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/post_documents.py
@@ -43,43 +43,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/enumerations/delete_global_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/delete_global_enumeration.py
@@ -32,31 +32,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/enumerations/delete_project_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/delete_project_enumeration.py
@@ -33,31 +33,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/enumerations/get_global_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/get_global_enumeration.py
@@ -55,31 +55,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/enumerations/get_project_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/get_project_enumeration.py
@@ -56,31 +56,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/enumerations/patch_global_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/patch_global_enumeration.py
@@ -44,39 +44,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/enumerations/patch_project_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/patch_project_enumeration.py
@@ -45,39 +45,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/enumerations/post_global_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/post_global_enumeration.py
@@ -45,43 +45,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/enumerations/post_project_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/post_project_enumeration.py
@@ -46,43 +46,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/delete_externally_linked_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/delete_externally_linked_work_item.py
@@ -35,31 +35,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/delete_externally_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/delete_externally_linked_work_items.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/get_externally_linked_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/get_externally_linked_work_item.py
@@ -63,31 +63,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/get_externally_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/get_externally_linked_work_items.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/post_externally_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/externally_linked_work_items/post_externally_linked_work_items.py
@@ -49,43 +49,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/feature_selections/get_feature_selection.py
+++ b/polarion_rest_api_client/open_api_client/api/feature_selections/get_feature_selection.py
@@ -62,31 +62,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/feature_selections/get_feature_selections.py
+++ b/polarion_rest_api_client/open_api_client/api/feature_selections/get_feature_selections.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/icons/get_default_icon.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_default_icon.py
@@ -48,31 +48,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/icons/get_default_icons.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_default_icons.py
@@ -53,31 +53,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/icons/get_global_icon.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_global_icon.py
@@ -48,31 +48,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/icons/get_global_icons.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_global_icons.py
@@ -53,31 +53,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/icons/get_project_icon.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_project_icon.py
@@ -49,31 +49,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/icons/get_project_icons.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_project_icons.py
@@ -54,31 +54,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/icons/post_global_icons.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/post_global_icons.py
@@ -39,43 +39,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/icons/post_project_icons.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/post_project_icons.py
@@ -40,43 +40,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/jobs/get_job.py
+++ b/polarion_rest_api_client/open_api_client/api/jobs/get_job.py
@@ -51,31 +51,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/jobs/get_job_result_file_content.py
+++ b/polarion_rest_api_client/open_api_client/api/jobs/get_job_result_file_content.py
@@ -31,31 +31,52 @@ def _parse_response(
         response_200 = cast(Any, None)
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/linked_oslc_resources/delete_oslc_resources.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_oslc_resources/delete_oslc_resources.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/linked_oslc_resources/get_oslc_resources.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_oslc_resources/get_oslc_resources.py
@@ -71,31 +71,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/linked_oslc_resources/post_oslc_resources.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_oslc_resources/post_oslc_resources.py
@@ -49,43 +49,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/delete_linked_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/delete_linked_work_item.py
@@ -34,31 +34,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/delete_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/delete_linked_work_items.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/get_linked_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/get_linked_work_item.py
@@ -62,31 +62,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/get_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/get_linked_work_items.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/patch_linked_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/patch_linked_work_item.py
@@ -46,39 +46,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/post_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/post_linked_work_items.py
@@ -49,43 +49,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/page_attachments/get_page_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/page_attachments/get_page_attachment.py
@@ -61,31 +61,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/page_attachments/get_page_attachment_content.py
+++ b/polarion_rest_api_client/open_api_client/api/page_attachments/get_page_attachment_content.py
@@ -44,31 +44,52 @@ def _parse_response(
         response_200 = cast(Any, None)
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/page_attachments/post_page_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/page_attachments/post_page_attachments.py
@@ -48,43 +48,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/pages/get_page.py
+++ b/polarion_rest_api_client/open_api_client/api/pages/get_page.py
@@ -56,31 +56,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/pages/patch_rich_page.py
+++ b/polarion_rest_api_client/open_api_client/api/pages/patch_rich_page.py
@@ -42,39 +42,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/delete_plan.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/delete_plan.py
@@ -31,31 +31,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/delete_plan_relationship.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/delete_plan_relationship.py
@@ -44,43 +44,73 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 405:
-        response_405 = Errors.from_dict(response.json())
+        try:
+            response_405 = Errors.from_dict(response.json())
+        except Exception:
+            response_405 = None
 
         return response_405
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/delete_plans.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/delete_plans.py
@@ -40,39 +40,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/get_plan.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/get_plan.py
@@ -55,31 +55,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/get_plan_relationship.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/get_plan_relationship.py
@@ -99,31 +99,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/get_plans.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/get_plans.py
@@ -69,31 +69,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/patch_plan.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/patch_plan.py
@@ -41,39 +41,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/patch_plan_relationships.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/patch_plan_relationships.py
@@ -53,39 +53,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/post_plan_relationships.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/post_plan_relationships.py
@@ -53,43 +53,73 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 405:
-        response_405 = Errors.from_dict(response.json())
+        try:
+            response_405 = Errors.from_dict(response.json())
+        except Exception:
+            response_405 = None
 
         return response_405
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/plans/post_plans.py
+++ b/polarion_rest_api_client/open_api_client/api/plans/post_plans.py
@@ -42,43 +42,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/project_templates/get_project_templates.py
+++ b/polarion_rest_api_client/open_api_client/api/project_templates/get_project_templates.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/create_project.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/create_project.py
@@ -41,31 +41,52 @@ def _parse_response(
 
         return response_202
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/delete_project.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/delete_project.py
@@ -32,15 +32,24 @@ def _parse_response(
 
         return response_202
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/delete_project_test_parameter_definition.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/delete_project_test_parameter_definition.py
@@ -31,31 +31,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/delete_project_test_parameter_definitions.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/delete_project_test_parameter_definitions.py
@@ -42,39 +42,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/get_project.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/get_project.py
@@ -54,31 +54,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/get_project_test_parameter_definition.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/get_project_test_parameter_definition.py
@@ -56,31 +56,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/get_project_test_parameter_definitions.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/get_project_test_parameter_definitions.py
@@ -61,31 +61,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/get_projects.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/get_projects.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/mark_project.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/mark_project.py
@@ -41,31 +41,52 @@ def _parse_response(
 
         return response_202
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/move_project_action.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/move_project_action.py
@@ -42,31 +42,52 @@ def _parse_response(
 
         return response_202
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/patch_project.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/patch_project.py
@@ -40,39 +40,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/post_project_test_parameter_definitions.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/post_project_test_parameter_definitions.py
@@ -48,43 +48,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/projects/unmark_project.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/unmark_project.py
@@ -32,19 +32,31 @@ def _parse_response(
 
         return response_202
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/revisions/get_revision.py
+++ b/polarion_rest_api_client/open_api_client/api/revisions/get_revision.py
@@ -52,31 +52,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/revisions/get_revisions.py
+++ b/polarion_rest_api_client/open_api_client/api/revisions/get_revisions.py
@@ -62,31 +62,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/roles/get_role.py
+++ b/polarion_rest_api_client/open_api_client/api/roles/get_role.py
@@ -53,31 +53,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_record_attachments/delete_test_record_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_record_attachments/delete_test_record_attachment.py
@@ -35,31 +35,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_record_attachments/delete_test_record_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_record_attachments/delete_test_record_attachments.py
@@ -46,39 +46,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_record_attachments/get_test_record_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_record_attachments/get_test_record_attachment.py
@@ -63,31 +63,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_record_attachments/get_test_record_attachment_content.py
+++ b/polarion_rest_api_client/open_api_client/api/test_record_attachments/get_test_record_attachment_content.py
@@ -46,31 +46,52 @@ def _parse_response(
         response_200 = cast(Any, None)
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_record_attachments/get_test_record_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_record_attachments/get_test_record_attachments.py
@@ -68,31 +68,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_record_attachments/patch_test_record_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_record_attachments/patch_test_record_attachment.py
@@ -45,39 +45,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_record_attachments/post_test_record_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_record_attachments/post_test_record_attachments.py
@@ -50,43 +50,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/delete_test_record.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/delete_test_record.py
@@ -34,31 +34,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/delete_test_record_test_parameter.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/delete_test_record_test_parameter.py
@@ -35,31 +35,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/get_test_record.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/get_test_record.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/get_test_record_test_parameter.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/get_test_record_test_parameter.py
@@ -63,31 +63,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/get_test_record_test_parameters.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/get_test_record_test_parameters.py
@@ -66,31 +66,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/get_test_records.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/get_test_records.py
@@ -70,31 +70,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/patch_test_record.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/patch_test_record.py
@@ -46,39 +46,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/patch_test_records.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/patch_test_records.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/post_test_record_test_parameters.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/post_test_record_test_parameters.py
@@ -52,43 +52,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_records/post_test_records.py
+++ b/polarion_rest_api_client/open_api_client/api/test_records/post_test_records.py
@@ -45,43 +45,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_attachments/delete_test_run_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_attachments/delete_test_run_attachment.py
@@ -32,31 +32,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_attachments/delete_test_run_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_attachments/delete_test_run_attachments.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_attachments/get_test_run_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_attachments/get_test_run_attachment.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_attachments/get_test_run_attachment_content.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_attachments/get_test_run_attachment_content.py
@@ -43,31 +43,52 @@ def _parse_response(
         response_200 = cast(Any, None)
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_attachments/get_test_run_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_attachments/get_test_run_attachments.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_attachments/patch_test_run_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_attachments/patch_test_run_attachment.py
@@ -42,39 +42,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_attachments/post_test_run_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_attachments/post_test_run_attachments.py
@@ -47,43 +47,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_comments/get_test_run_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_comments/get_test_run_comment.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_comments/get_test_run_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_comments/get_test_run_comments.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_comments/patch_test_run_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_comments/patch_test_run_comment.py
@@ -44,39 +44,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_comments/patch_test_run_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_comments/patch_test_run_comments.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_run_comments/post_test_run_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_run_comments/post_test_run_comments.py
@@ -49,43 +49,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_run.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_run.py
@@ -31,31 +31,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_run_test_parameter.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_run_test_parameter.py
@@ -32,31 +32,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_run_test_parameter_definition.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_run_test_parameter_definition.py
@@ -32,31 +32,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_run_test_parameters.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_run_test_parameters.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_runs.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/delete_test_runs.py
@@ -40,39 +40,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/get_export_excel_tests.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/get_export_excel_tests.py
@@ -50,39 +50,66 @@ def _parse_response(
 
         return response_202
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run.py
@@ -55,31 +55,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run_test_parameter.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run_test_parameter.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run_test_parameter_definition.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run_test_parameter_definition.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run_test_parameter_definitions.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run_test_parameter_definitions.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run_test_parameters.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/get_test_run_test_parameters.py
@@ -63,31 +63,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/get_test_runs.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/get_test_runs.py
@@ -69,31 +69,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/get_workflow_actions_for_test_run.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/get_workflow_actions_for_test_run.py
@@ -54,31 +54,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/import_excel_test_results.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/import_excel_test_results.py
@@ -43,35 +43,59 @@ def _parse_response(
 
         return response_202
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/import_x_unit_test_results.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/import_x_unit_test_results.py
@@ -42,35 +42,59 @@ def _parse_response(
 
         return response_202
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/patch_test_run.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/patch_test_run.py
@@ -41,39 +41,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/patch_test_runs.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/patch_test_runs.py
@@ -40,39 +40,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/post_test_run_parameter_definitions.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/post_test_run_parameter_definitions.py
@@ -49,43 +49,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/post_test_run_test_parameters.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/post_test_run_test_parameters.py
@@ -49,43 +49,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_runs/post_test_runs.py
+++ b/polarion_rest_api_client/open_api_client/api/test_runs/post_test_runs.py
@@ -42,43 +42,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/delete_test_step_result_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/delete_test_step_result_attachment.py
@@ -36,31 +36,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/delete_test_step_result_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/delete_test_step_result_attachments.py
@@ -47,39 +47,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/get_test_step_result_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/get_test_step_result_attachment.py
@@ -64,31 +64,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/get_test_step_result_attachment_content.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/get_test_step_result_attachment_content.py
@@ -47,31 +47,52 @@ def _parse_response(
         response_200 = cast(Any, None)
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/get_test_step_result_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/get_test_step_result_attachments.py
@@ -69,31 +69,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/patch_test_step_result_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/patch_test_step_result_attachment.py
@@ -46,39 +46,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/post_test_step_result_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_result_attachments/post_test_step_result_attachments.py
@@ -51,43 +51,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_results/get_test_step_result.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_results/get_test_step_result.py
@@ -63,31 +63,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_results/get_test_step_results.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_results/get_test_step_results.py
@@ -68,31 +68,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_results/patch_test_step_result.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_results/patch_test_step_result.py
@@ -47,39 +47,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_results/patch_test_step_results.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_results/patch_test_step_results.py
@@ -46,39 +46,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_step_results/post_test_step_results.py
+++ b/polarion_rest_api_client/open_api_client/api/test_step_results/post_test_step_results.py
@@ -52,43 +52,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_steps/delete_test_step.py
+++ b/polarion_rest_api_client/open_api_client/api/test_steps/delete_test_step.py
@@ -32,31 +32,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_steps/delete_test_steps.py
+++ b/polarion_rest_api_client/open_api_client/api/test_steps/delete_test_steps.py
@@ -41,39 +41,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_steps/get_test_step.py
+++ b/polarion_rest_api_client/open_api_client/api/test_steps/get_test_step.py
@@ -56,31 +56,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_steps/get_test_steps.py
+++ b/polarion_rest_api_client/open_api_client/api/test_steps/get_test_steps.py
@@ -61,31 +61,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_steps/patch_test_step.py
+++ b/polarion_rest_api_client/open_api_client/api/test_steps/patch_test_step.py
@@ -44,39 +44,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_steps/patch_test_steps.py
+++ b/polarion_rest_api_client/open_api_client/api/test_steps/patch_test_steps.py
@@ -41,39 +41,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/test_steps/post_test_steps.py
+++ b/polarion_rest_api_client/open_api_client/api/test_steps/post_test_steps.py
@@ -43,43 +43,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/user_groups/get_user_group.py
+++ b/polarion_rest_api_client/open_api_client/api/user_groups/get_user_group.py
@@ -56,31 +56,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/users/get_avatar.py
+++ b/polarion_rest_api_client/open_api_client/api/users/get_avatar.py
@@ -30,31 +30,52 @@ def _parse_response(
         response_200 = cast(Any, None)
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/users/get_user.py
+++ b/polarion_rest_api_client/open_api_client/api/users/get_user.py
@@ -54,31 +54,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/users/get_users.py
+++ b/polarion_rest_api_client/open_api_client/api/users/get_users.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/users/patch_user.py
+++ b/polarion_rest_api_client/open_api_client/api/users/patch_user.py
@@ -40,39 +40,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/users/post_users.py
+++ b/polarion_rest_api_client/open_api_client/api/users/post_users.py
@@ -41,43 +41,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/users/set_license.py
+++ b/polarion_rest_api_client/open_api_client/api/users/set_license.py
@@ -40,39 +40,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/users/update_avatar.py
+++ b/polarion_rest_api_client/open_api_client/api/users/update_avatar.py
@@ -38,39 +38,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_approvals/delete_approval.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_approvals/delete_approval.py
@@ -32,31 +32,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_approvals/delete_approvals.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_approvals/delete_approvals.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_approvals/get_work_item_approval.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_approvals/get_work_item_approval.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_approvals/get_work_item_approvals.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_approvals/get_work_item_approvals.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_approvals/patch_work_item_approval.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_approvals/patch_work_item_approval.py
@@ -44,39 +44,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_approvals/patch_work_item_approvals.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_approvals/patch_work_item_approvals.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_approvals/post_work_item_approvals.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_approvals/post_work_item_approvals.py
@@ -49,43 +49,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/delete_work_item_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/delete_work_item_attachment.py
@@ -32,31 +32,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachment.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachment_content.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachment_content.py
@@ -43,31 +43,52 @@ def _parse_response(
         response_200 = cast(Any, None)
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachments.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/patch_work_item_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/patch_work_item_attachment.py
@@ -42,39 +42,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/post_work_item_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/post_work_item_attachments.py
@@ -47,43 +47,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_comments/get_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_comments/get_comment.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_comments/get_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_comments/get_comments.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_comments/patch_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_comments/patch_comment.py
@@ -44,39 +44,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_comments/post_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_comments/post_comments.py
@@ -49,43 +49,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_work_records/delete_work_record.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_work_records/delete_work_record.py
@@ -32,31 +32,52 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_work_records/delete_work_records.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_work_records/delete_work_records.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_work_records/get_work_record.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_work_records/get_work_record.py
@@ -58,31 +58,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_work_records/get_work_records.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_work_records/get_work_records.py
@@ -61,31 +61,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_item_work_records/post_work_records.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_work_records/post_work_records.py
@@ -45,43 +45,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/delete_all_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/delete_all_work_items.py
@@ -39,35 +39,59 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/delete_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/delete_work_items.py
@@ -40,39 +40,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/delete_work_items_relationship.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/delete_work_items_relationship.py
@@ -44,43 +44,73 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 405:
-        response_405 = Errors.from_dict(response.json())
+        try:
+            response_405 = Errors.from_dict(response.json())
+        except Exception:
+            response_405 = None
 
         return response_405
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_all_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_all_work_items.py
@@ -65,27 +65,45 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_available_enum_options_for_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_available_enum_options_for_work_item.py
@@ -50,31 +50,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_available_enum_options_for_work_item_type.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_available_enum_options_for_work_item_type.py
@@ -52,31 +52,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_current_enum_options_for_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_current_enum_options_for_work_item.py
@@ -53,31 +53,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_work_item.py
@@ -55,31 +55,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_work_item_test_parameter_definition.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_work_item_test_parameter_definition.py
@@ -60,31 +60,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_work_item_test_parameter_definitions.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_work_item_test_parameter_definitions.py
@@ -65,31 +65,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_work_items.py
@@ -66,31 +66,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_work_items_relationships.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_work_items_relationships.py
@@ -99,31 +99,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_workflow_actions_for_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_workflow_actions_for_work_item.py
@@ -54,31 +54,52 @@ def _parse_response(
 
         return response_200
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/move_from_document.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/move_from_document.py
@@ -31,27 +31,45 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/move_to_document.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/move_to_document.py
@@ -43,39 +43,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/patch_all_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/patch_all_work_items.py
@@ -49,35 +49,59 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/patch_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/patch_work_item.py
@@ -56,39 +56,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/patch_work_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/patch_work_item_relationships.py
@@ -53,39 +53,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/patch_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/patch_work_items.py
@@ -53,39 +53,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/post_work_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/post_work_item_relationships.py
@@ -53,39 +53,66 @@ def _parse_response(
         response_204 = cast(Any, None)
         return response_204
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/polarion_rest_api_client/open_api_client/api/work_items/post_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/post_work_items.py
@@ -42,43 +42,73 @@ def _parse_response(
 
         return response_201
     if response.status_code == 400:
-        response_400 = Errors.from_dict(response.json())
+        try:
+            response_400 = Errors.from_dict(response.json())
+        except Exception:
+            response_400 = None
 
         return response_400
     if response.status_code == 401:
-        response_401 = Errors.from_dict(response.json())
+        try:
+            response_401 = Errors.from_dict(response.json())
+        except Exception:
+            response_401 = None
 
         return response_401
     if response.status_code == 403:
-        response_403 = Errors.from_dict(response.json())
+        try:
+            response_403 = Errors.from_dict(response.json())
+        except Exception:
+            response_403 = None
 
         return response_403
     if response.status_code == 404:
-        response_404 = Errors.from_dict(response.json())
+        try:
+            response_404 = Errors.from_dict(response.json())
+        except Exception:
+            response_404 = None
 
         return response_404
     if response.status_code == 406:
-        response_406 = Errors.from_dict(response.json())
+        try:
+            response_406 = Errors.from_dict(response.json())
+        except Exception:
+            response_406 = None
 
         return response_406
     if response.status_code == 409:
-        response_409 = Errors.from_dict(response.json())
+        try:
+            response_409 = Errors.from_dict(response.json())
+        except Exception:
+            response_409 = None
 
         return response_409
     if response.status_code == 413:
-        response_413 = Errors.from_dict(response.json())
+        try:
+            response_413 = Errors.from_dict(response.json())
+        except Exception:
+            response_413 = None
 
         return response_413
     if response.status_code == 415:
-        response_415 = Errors.from_dict(response.json())
+        try:
+            response_415 = Errors.from_dict(response.json())
+        except Exception:
+            response_415 = None
 
         return response_415
     if response.status_code == 500:
-        response_500 = Errors.from_dict(response.json())
+        try:
+            response_500 = Errors.from_dict(response.json())
+        except Exception:
+            response_500 = None
 
         return response_500
     if response.status_code == 503:
-        response_503 = Errors.from_dict(response.json())
+        try:
+            response_503 = Errors.from_dict(response.json())
+        except Exception:
+            response_503 = None
 
         return response_503
     if client.raise_on_unexpected_status:

--- a/tests/test_client_error_responses.py
+++ b/tests/test_client_error_responses.py
@@ -52,3 +52,42 @@ def test_dont_retry_on_404(
     e = e_info.value
     assert len(httpx_mock.get_requests()) == 1
     assert e.args[0] == 404
+
+
+def test_html_error_body_raises_unexpected_exception(
+    client: polarion_api.ProjectClient,
+    httpx_mock: pytest_httpx.HTTPXMock,
+):
+    """A non-JSON (e.g. HTML) error body must not raise JSONDecodeError."""
+    html_body = (
+        b"<!DOCTYPE HTML><html><head><title>401</title></head>"
+        b"<body><h1>401 Unauthorized</h1></body></html>"
+    )
+    for _ in range(5):
+        httpx_mock.add_response(
+            status_code=401,
+            headers={"content-type": "text/html; charset=iso-8859-1"},
+            content=html_body,
+        )
+
+    with pytest.raises(polarion_api.PolarionApiUnexpectedException) as e_info:
+        client.work_items.get_multi()
+
+    assert len(httpx_mock.get_requests()) == 5
+    assert e_info.value.args[0] == 401
+    assert html_body in e_info.value.args[1]
+
+
+def test_empty_error_body_raises_unexpected_exception(
+    client: polarion_api.ProjectClient,
+    httpx_mock: pytest_httpx.HTTPXMock,
+):
+    """An empty error body must not raise JSONDecodeError."""
+    for _ in range(5):
+        httpx_mock.add_response(status_code=400, content=b"")
+
+    with pytest.raises(polarion_api.PolarionApiUnexpectedException) as e_info:
+        client.work_items.get_multi()
+
+    assert len(httpx_mock.get_requests()) == 5
+    assert e_info.value.args[0] == 400


### PR DESCRIPTION
Solve #84

Explanation why fix is done with regex in build_client.py (post-generation-fix):

**Summary**

- Regex correctness: confirmed - produces identical output to the manual patch
- Path correctness: confirmed - output_path / "api" resolves to api, the directory with all 220 files
- Why regex is the right call here: you're correct that the template approach was ruled out. The Errors.from_dict(response.json()) line is assembled across three template files (endpoint_module.py.jinja → endpoint_macros.py.jinja → model_property.py.jinja → property_macros.py.jinja). The only hook point is parse_response in endpoint_macros.py.jinja, but overriding that requires duplicating the full upstream macro which includes unrelated body-parsing logic, and would silently break on any generator update. Post-processing in build_client.py is the established pattern there (it already does regex manipulation on the OpenAPI spec before generation) and the target string response_NNN = Errors.from_dict(response.json()) is 100% generator-stable - that exact form appears nowhere else and will always be produced by model_property.py.jinja.