### PR TITLE
feat: Add document renderer from capella2polarion

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+docs/examples/document_rendering_examples.ipynb

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,14 @@
+<!--
+ ~ Copyright DB InfraGO AG and contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+# Document Rendering Examples
+
+This folder contains example assets for the document rendering API.
+
+## Files
+
+- `templates/basic_document.j2`: template for full document rendering
+- `templates/mixed_authority_section.j2`: template for section updates
+- `mixed_authority_document.html`: example mixed-authority source HTML

--- a/docs/examples/document_rendering_examples.ipynb.license
+++ b/docs/examples/document_rendering_examples.ipynb.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+SPDX-License-Identifier: Apache-2.0

--- a/docs/examples/mixed_authority_document.html
+++ b/docs/examples/mixed_authority_document.html
@@ -1,0 +1,15 @@
+<!--
+ ~ Copyright DB InfraGO AG and contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+<p>Intro written manually in Polarion.</p>
+<div class="polarion-dle-wiki-block">
+  <div class="polarion-dle-wiki-block-source">&lt;div class=&quot;autoRenderAreaStart&quot; id=&quot;IcdContent&quot;&gt;&lt;/div&gt;</div>
+</div>
+<h2 id="polarion_wiki macro name=module-workitem;params=id=REQ-42"></h2>
+<p>This area is generated and will be replaced.</p>
+<div class="polarion-dle-wiki-block">
+  <div class="polarion-dle-wiki-block-source">&lt;div class=&quot;autoRenderAreaEnd&quot; id=&quot;IcdContent&quot;&gt;&lt;/div&gt;</div>
+</div>
+<p>Outro written manually in Polarion.</p>

--- a/docs/examples/templates/basic_document.j2
+++ b/docs/examples/templates/basic_document.j2
@@ -1,0 +1,13 @@
+{#
+Copyright DB InfraGO AG and contributors
+SPDX-License-Identifier: Apache-2.0
+#}
+
+{{ heading(1, "System Overview", session) }}
+<p>This section was generated from a Jinja template.</p>
+{{ insert_work_item(requirement_id, session) }}
+<p>See also: {{ requirement_id | link_work_item }}</p>
+
+<workitem id="txt-introduction">
+  <p><strong>Introduction:</strong> This text block is managed as a text work item.</p>
+</workitem>

--- a/docs/examples/templates/mixed_authority_section.j2
+++ b/docs/examples/templates/mixed_authority_section.j2
@@ -1,0 +1,13 @@
+{#
+Copyright DB InfraGO AG and contributors
+SPDX-License-Identifier: Apache-2.0
+#}
+
+{{ heading(2, "ICD Auto Content", session) }}
+<p>Generated for release {{ release_name }}.</p>
+
+<workitem id="txt-icd-summary">
+  <p>Auto-generated summary for {{ system_name }}.</p>
+</workitem>
+
+{{ insert_work_item(primary_requirement, session) }}

--- a/docs/source/document_rendering.rst
+++ b/docs/source/document_rendering.rst
@@ -157,7 +157,7 @@ In the Polarion UI, a typical marker source can look like this:
 
 .. code-block:: html
 
-   <div class="c2pAreaStart" id="IcdContent">
+   <div class="autoRenderAreaStart" id="IcdContent">
    #set($statusList = ["draft", "planned", "inReview"])
    #if ($statusList.contains($document.getStatus().id))
    <p style="font-weight: bold;background-color: #FFFF00;text-align: center;">
@@ -169,12 +169,12 @@ In the Polarion UI, a typical marker source can look like this:
 
    <!-- ... generated content goes here ... -->
 
-   <div class="c2pAreaEnd" id="IcdContent"></div>
+   <div class="autoRenderAreaEnd" id="IcdContent"></div>
 
 Important rules:
 
 - area IDs must match between start and end markers
-- marker classes must be exactly ``c2pAreaStart`` and ``c2pAreaEnd``
+- marker classes must match the configured renderer marker classes
 - each start marker must have a corresponding end marker
 - each marker must be inside a Polarion wiki block source section
 - only content between markers is overwritten during mixed-authority updates

--- a/docs/source/document_rendering.rst
+++ b/docs/source/document_rendering.rst
@@ -1,0 +1,265 @@
+..
+   Copyright DB InfraGO AG and contributors
+   SPDX-License-Identifier: Apache-2.0
+
+Document Rendering
+==================
+
+The package provides a generic, non-project-specific rendering layer for
+Polarion documents in ``polarion_rest_api_client.document_rendering``.
+
+Import the rendering API from the dedicated submodule:
+
+.. code-block:: python
+
+   import polarion_rest_api_client as polarion_api
+   import polarion_rest_api_client.document_rendering as rendering
+
+Core entry points
+-----------------
+
+- ``DocumentRenderer`` renders full documents from Jinja templates and can
+  update existing documents.
+- ``update_mixed_authority_document`` updates configurable areas in
+  mixed-authority documents while preserving user-managed content.
+- ``TextWorkItemProvider`` creates and reuses text work items represented as
+  ``<workitem id="...">`` placeholders in templates.
+
+
+How The Rendering Pipeline Works
+--------------------------------
+
+``DocumentRenderer`` has two modes:
+
+- ``render_document`` for complete document rendering from a template
+- ``update_mixed_authority_document`` for section-only updates in existing
+  documents
+
+Both modes render Jinja first and then process generated HTML fragments.
+``TextWorkItemProvider`` is used to detect ``<workitem id="...">`` elements,
+create/update matching text work items, and replace placeholders with
+Polarion macro DIV elements.
+
+
+Rendering a document
+--------------------
+
+Minimal example with explicit work item tuple:
+
+.. code-block:: python
+
+   renderer = rendering.DocumentRenderer(default_project_id="PROJ")
+   req = polarion_api.WorkItem(id="REQ-1", type="requirement")
+
+   result = renderer.render_document(
+       template_folder="templates",
+       template_name="document.j2",
+       polarion_folder="_default",
+       polarion_name="SPEC-001",
+       item=("PROJ", req),
+   )
+
+   document = result.document
+
+
+Work item lookup modes
+----------------------
+
+``DocumentRenderer`` supports multiple lookup approaches:
+
+- explicit ``(project_id, WorkItem)`` tuples in templates
+- ``work_item_repository`` lookups by ``(project_id, work_item_id)``
+- string IDs with ``default_project_id``
+- a custom ``work_item_lookup`` callback
+
+Repository lookup example:
+
+.. code-block:: python
+
+   renderer = rendering.DocumentRenderer(
+       default_project_id="PROJ",
+       work_item_repository={
+           ("PROJ", "REQ-2"): polarion_api.WorkItem(
+               id="REQ-2",
+               type="requirement",
+               title="Safety requirement",
+           )
+       },
+   )
+
+   # In Jinja, ``item_id`` can now be "REQ-2"
+   # and it will be resolved via the repository.
+
+Callback lookup example:
+
+.. code-block:: python
+
+   def lookup_custom_object(obj: object) -> tuple[str | None, polarion_api.WorkItem | None]:
+       if isinstance(obj, dict) and obj.get("id") == "REQ-5":
+           return "PROJ", polarion_api.WorkItem(
+               id="REQ-5",
+               type="requirement",
+           )
+       return None, None
+
+   renderer = rendering.DocumentRenderer(
+       default_project_id="PROJ",
+       work_item_lookup=lookup_custom_object,
+   )
+
+Subclassing is still supported; project-specific renderers can override
+``resolve_work_item`` and optionally call ``super().resolve_work_item(...)``
+for fallback behavior.
+
+Jinja helpers
+-------------
+
+``DocumentRenderer`` registers template helpers:
+
+- ``insert_work_item(obj, session, level=None)``
+- ``heading(level, text, session)``
+- ``work_item_field(obj, field)``
+- ``generate_image_html(title, attachment_id, max_width, css_class, caption=None)``
+- filter ``link_work_item``
+
+Template example:
+
+.. code-block:: jinja
+
+   {{ heading(1, "System requirements", session) }}
+   {{ insert_work_item(item_id, session) }}
+   <p>Reference: {{ item_id | link_work_item }}</p>
+
+Mixed-authority updates
+-----------------------
+
+Use ``update_mixed_authority_document`` to replace template-managed sections
+while preserving manually maintained content.
+
+.. code-block:: python
+
+   result = renderer.update_mixed_authority_document(
+       document=existing_document,
+       template_folder="templates",
+       sections={"overview": "overview.j2"},
+       global_parameters={"version": "1.2"},
+       section_parameters={"overview": {"author": "DB"}},
+   )
+
+
+Defining Mixed-Authority Areas With Wiki Macros
+------------------------------------------------
+
+For mixed-authority updates, each auto-generated section must be wrapped by
+a start/end area marker inside Polarion wiki-macro source blocks.
+
+In the Polarion UI, a typical marker source can look like this:
+
+.. code-block:: html
+
+   <div class="c2pAreaStart" id="IcdContent">
+   #set($statusList = ["draft", "planned", "inReview"])
+   #if ($statusList.contains($document.getStatus().id))
+   <p style="font-weight: bold;background-color: #FFFF00;text-align: center;">
+   DON'T REMOVE THIS<br>
+   ↓↓↓Below this point all content is autogenerated and will be overwritten↓↓↓
+   </p>
+   #end
+   </div>
+
+   <!-- ... generated content goes here ... -->
+
+   <div class="c2pAreaEnd" id="IcdContent"></div>
+
+Important rules:
+
+- area IDs must match between start and end markers
+- marker classes must be exactly ``c2pAreaStart`` and ``c2pAreaEnd``
+- each start marker must have a corresponding end marker
+- each marker must be inside a Polarion wiki block source section
+- only content between markers is overwritten during mixed-authority updates
+
+By default, ``DocumentRenderer`` expects marker classes
+``autoRenderAreaStart`` and ``autoRenderAreaEnd``. You can override these via
+``area_start_class=...`` and ``area_end_class=...`` in the constructor.
+
+Internally, the parser reads these markers from HTML rendered by Polarion
+wiki macros (``div.polarion-dle-wiki-block`` +
+``div.polarion-dle-wiki-block-source``).
+
+
+TextWorkItemProvider In Practice
+--------------------------------
+
+``TextWorkItemProvider`` supports both creation and reuse of text work items.
+
+1. add ``<workitem id="...">...</workitem>`` in templates
+2. call ``generate_text_work_items(...)`` on rendered fragments
+3. create/update those work items via API using
+   ``new_text_work_items.values()``
+4. call ``insert_text_work_items(document)`` to replace placeholders in
+   document HTML with Polarion macro DIV elements
+
+Minimal pattern:
+
+.. code-block:: python
+
+   provider = rendering.TextWorkItemProvider(
+       existing_text_work_items=already_existing_text_wis,
+   )
+
+   result = renderer.render_document(
+       template_folder="templates",
+       template_name="basic_document.j2",
+       polarion_folder="_default",
+       polarion_name="SPEC-1",
+       text_work_item_provider=provider,
+   )
+
+   # Create/update result.text_work_item_provider.new_text_work_items via API,
+   # then place references into result.document HTML.
+   result.text_work_item_provider.insert_text_work_items(result.document)
+
+
+HTML helper functions
+---------------------
+
+Utility functions in ``polarion_rest_api_client.document_rendering.html_utils``
+can be used independently from ``DocumentRenderer``.
+
+Common helpers:
+
+- ``generate_image_html``: generate Polarion image HTML with optional caption
+- ``extract_work_items`` / ``extract_headings``: parse work item references
+- ``get_layout_index``: find or append rendering layout entries
+- ``remove_table_ids``: strip table IDs to avoid Polarion duplicate-ID issues
+- ``camel_case_to_words``: user-friendly labels from type names
+- ``strike_through``: mark removed references in generated HTML
+
+Examples
+--------
+
+Usable examples are provided in the repository:
+
+- notebook: ``docs/examples/document_rendering_examples.ipynb``
+- basic document template: ``docs/examples/templates/basic_document.j2``
+- mixed-authority section template:
+  ``docs/examples/templates/mixed_authority_section.j2``
+- mixed-authority sample content with area markers:
+  ``docs/examples/mixed_authority_document.html``
+
+.. code-block:: python
+
+   from polarion_rest_api_client.document_rendering import html_utils
+
+   html = html_utils.generate_image_html(
+       title="Architecture",
+       attachment_id="arch.svg",
+       max_width=900,
+       css_class="diagram",
+       caption=("Figure", "Logical architecture"),
+   )
+
+   ids = html_utils.extract_work_items(
+       '<div id="polarion_wiki macro name=module-workitem;params=id=REQ-10"></div>'
+   )

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,8 @@ Welcome to polarion-rest-api-client's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   document_rendering
+
 .. toctree::
    :maxdepth: 3
    :caption: API reference

--- a/polarion_rest_api_client/document_rendering/__init__.py
+++ b/polarion_rest_api_client/document_rendering/__init__.py
@@ -1,0 +1,61 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Public API for rendering Polarion documents with Jinja2."""
+
+from polarion_rest_api_client.document_rendering.document_renderer import (
+    DocumentRenderer,
+)
+from polarion_rest_api_client.document_rendering.html_utils import (
+    POLARION_WORK_ITEM_DOCUMENT,
+    POLARION_WORK_ITEM_DOCUMENT_PROJECT,
+    POLARION_WORK_ITEM_URL,
+    POLARION_WORK_ITEM_URL_PROJECT,
+    RED_TEXT,
+    TEXT_WORK_ITEM_ID_FIELD,
+    TEXT_WORK_ITEM_TYPE,
+    WI_ID_PREFIX,
+    WI_ID_REGEX,
+    WI_PROJECT_REGEX,
+    WORK_ITEM_TAG,
+    camel_case_to_words,
+    ensure_fragments,
+    extract_headings,
+    extract_work_items,
+    generate_image_html,
+    get_layout_index,
+    remove_table_ids,
+    strike_through,
+)
+from polarion_rest_api_client.document_rendering.rendering_session import (
+    DocumentData,
+    RenderingSession,
+)
+from polarion_rest_api_client.document_rendering.text_work_item_provider import (
+    TextWorkItemProvider,
+)
+
+__all__ = [
+    "POLARION_WORK_ITEM_DOCUMENT",
+    "POLARION_WORK_ITEM_DOCUMENT_PROJECT",
+    "POLARION_WORK_ITEM_URL",
+    "POLARION_WORK_ITEM_URL_PROJECT",
+    "RED_TEXT",
+    "TEXT_WORK_ITEM_ID_FIELD",
+    "TEXT_WORK_ITEM_TYPE",
+    "WI_ID_PREFIX",
+    "WI_ID_REGEX",
+    "WI_PROJECT_REGEX",
+    "WORK_ITEM_TAG",
+    "DocumentData",
+    "DocumentRenderer",
+    "RenderingSession",
+    "TextWorkItemProvider",
+    "camel_case_to_words",
+    "ensure_fragments",
+    "extract_headings",
+    "extract_work_items",
+    "generate_image_html",
+    "get_layout_index",
+    "remove_table_ids",
+    "strike_through",
+]

--- a/polarion_rest_api_client/document_rendering/document_renderer.py
+++ b/polarion_rest_api_client/document_rendering/document_renderer.py
@@ -1,0 +1,514 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+"""A generic Jinja renderer for Polarion documents."""
+
+from __future__ import annotations
+
+import html
+import logging
+import pathlib
+import typing as t
+from collections.abc import Mapping
+
+import jinja2
+from lxml import html as lxmlhtml  # type: ignore[import-not-found]
+
+from polarion_rest_api_client import data_models as polarion_api
+
+from . import html_utils
+from .rendering_session import (
+    DocumentData,
+    RenderingSession,
+    WorkItemLookup,
+    WorkItemLookupResult,
+)
+from .text_work_item_provider import TextWorkItemProvider
+
+PROJ_WI_PAIR_LEN = 2
+
+DEFAULT_AREA_START_CLS = "autoRenderAreaStart"
+"""Default marker class for the wiki macro that starts a rendering area."""
+DEFAULT_AREA_END_CLS = "autoRenderAreaEnd"
+"""Default marker class for the wiki macro that ends a rendering area."""
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentRenderer:
+    """A generic renderer for Polarion documents.
+
+    The renderer can resolve explicit ``(project_id, WorkItem)`` pairs and
+    ``(project_id, work_item_id)`` or ``work_item_id`` references through an
+    internal lookup repository.
+    For project-specific object models, subclass it and override
+    :meth:`resolve_work_item` and optionally :meth:`get_template_context`.
+    Alternatively, pass a ``work_item_lookup`` callback to the constructor.
+    """
+
+    def __init__(
+        self,
+        default_project_id: str | None = None,
+        *,
+        work_item_lookup: WorkItemLookup | None = None,
+        work_item_repository: (
+            Mapping[tuple[str, str], polarion_api.WorkItem] | None
+        ) = None,
+        area_start_class: str = DEFAULT_AREA_START_CLS,
+        area_end_class: str = DEFAULT_AREA_END_CLS,
+        extra_template_context: dict[str, t.Any] | None = None,
+    ) -> None:
+        self.jinja_envs: dict[str, jinja2.Environment] = {}
+        self.default_project_id = default_project_id
+        self._work_item_lookup = work_item_lookup
+        self._work_item_repository = dict(work_item_repository or {})
+        self.area_start_class = area_start_class
+        self.area_end_class = area_end_class
+        self._extra_template_context = extra_template_context or {}
+
+    def _get_jinja_env(
+        self, template_folder: str | pathlib.Path
+    ) -> jinja2.Environment:
+        """Get or create a Jinja environment for a template folder."""
+        template_folder = str(template_folder)
+        if env := self.jinja_envs.get(template_folder):
+            return env
+
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(template_folder)
+        )
+        self.setup_env(env)
+        self.jinja_envs[template_folder] = env
+        return env
+
+    def setup_env(self, env: jinja2.Environment) -> None:
+        """Add globals and filters to the environment."""
+        env.globals["insert_work_item"] = self._insert_work_item
+        env.globals["heading"] = self._heading
+        env.globals["work_item_field"] = self._work_item_field
+        env.globals["generate_image_html"] = html_utils.generate_image_html
+        env.filters["link_work_item"] = self._link_work_item
+
+    def get_template_context(self) -> dict[str, t.Any]:
+        """Return default template context values for each render."""
+        return dict(self._extra_template_context)
+
+    @t.overload
+    def resolve_work_item(self, obj: object) -> WorkItemLookupResult: ...
+
+    @t.overload
+    def resolve_work_item(
+        self, project_id: str, work_item_id: str
+    ) -> WorkItemLookupResult: ...
+
+    def resolve_work_item(
+        self, obj: object, work_item_id: str | None = None
+    ) -> WorkItemLookupResult:
+        """Resolve a custom object into a Polarion work item.
+
+        The default implementation supports lookups by ``(project_id,
+        work_item_id)`` and by ``work_item_id`` with ``default_project_id``.
+        For non-string objects, the default implementation delegates to the
+        optional callback supplied at construction time.
+        """
+        if work_item_id is not None:
+            if not isinstance(obj, str):
+                logger.error(
+                    "Invalid work item lookup input: project_id must be a string, got %r.",
+                    obj,
+                )
+                return None, None
+            return self._resolve_work_item_from_repository(obj, work_item_id)
+
+        if isinstance(obj, str):
+            if self.default_project_id is None:
+                logger.error(
+                    "Invalid work item lookup input: no default project configured for id %s.",
+                    obj,
+                )
+                return None, None
+            return self._resolve_work_item_from_repository(
+                self.default_project_id, obj
+            )
+
+        if self._work_item_lookup is not None:
+            return self._work_item_lookup(obj)
+        logger.error("Invalid work item lookup input: %r", obj)
+        return None, None
+
+    def _resolve_work_item_from_repository(
+        self, project_id: str, work_item_id: str
+    ) -> WorkItemLookupResult:
+        work_item = self._work_item_repository.get((project_id, work_item_id))
+        if work_item is None:
+            logger.info(
+                "WorkItem %s/%s was not found in the renderer lookup repository.",
+                project_id,
+                work_item_id,
+            )
+            return project_id, None
+        return project_id, work_item
+
+    def _get_work_item(self, obj: object) -> WorkItemLookupResult:
+        if isinstance(obj, tuple) and len(obj) == PROJ_WI_PAIR_LEN:
+            proj_id, work_item = obj
+            if isinstance(proj_id, str) and isinstance(
+                work_item, polarion_api.WorkItem
+            ):
+                if work_item.id:
+                    self._work_item_repository[(proj_id, work_item.id)] = (
+                        work_item
+                    )
+                return proj_id, work_item
+            if isinstance(proj_id, str) and isinstance(work_item, str):
+                return self.resolve_work_item(proj_id, work_item)
+            logger.error("Invalid work item tuple input: %r", obj)
+            return None, None
+
+        if isinstance(obj, str):
+            return self.resolve_work_item(obj)
+
+        if jinja2.is_undefined(obj) or obj is None:
+            logger.error("Invalid work item input: %r", obj)
+            return None, None
+
+        return self.resolve_work_item(obj)
+
+    def _insert_work_item(
+        self, obj: object, session: RenderingSession, level: int | None = None
+    ) -> str:
+        proj_id, work_item = self._get_work_item(obj)
+
+        if proj_id and work_item:
+            assert work_item.id
+            if (proj_id, work_item.id) in session.inserted_work_item_ids:
+                logger.warning(
+                    "WorkItem %s is already in the document."
+                    "A link will be added instead of inserting it.",
+                    work_item.id,
+                )
+                return f"<p>{self._link_work_item(obj)}</p>"
+
+            assert work_item.type
+            layout_index = html_utils.get_layout_index(
+                "section",
+                session.rendering_layouts,
+                work_item.type,
+            )
+
+            custom_info = ""
+            if level is not None:
+                custom_info = f"level={level}|"
+
+            session.inserted_work_item_ids.append((proj_id, work_item.id))
+            if proj_id != session.document_project_id:
+                return html_utils.POLARION_WORK_ITEM_DOCUMENT_PROJECT.format(
+                    pid=work_item.id,
+                    lid=layout_index,
+                    custom_info=custom_info,
+                    project=proj_id,
+                )
+            return html_utils.POLARION_WORK_ITEM_DOCUMENT.format(
+                pid=work_item.id,
+                lid=layout_index,
+                custom_info=custom_info,
+            )
+
+        logger.warning("Error inserting work item for input: %r", obj)
+        return html_utils.RED_TEXT.format(text="Error inserting work item.")
+
+    def _link_work_item(self, obj: object) -> str:
+        proj_id, work_item = self._get_work_item(obj)
+
+        if work_item and proj_id:
+            return html_utils.POLARION_WORK_ITEM_URL_PROJECT.format(
+                pid=work_item.id,
+                project=proj_id,
+            )
+
+        logger.warning("Error linking work item for input: %r", obj)
+        return html_utils.RED_TEXT.format(text="Error linking work item.")
+
+    def _heading(
+        self, level: int, text: str, session: RenderingSession
+    ) -> str:
+        if session.heading_ids:
+            hid = session.heading_ids.pop(0)
+            session.headings.append(polarion_api.WorkItem(id=hid, title=text))
+            return f'<h{level} id="{html_utils.WI_ID_PREFIX}{hid}"></h{level}>'
+        return f"<h{level}>{text}</h{level}>"
+
+    def _work_item_field(self, obj: object, field: str) -> t.Any:
+        _, work_item = self._get_work_item(obj)
+        if work_item is None:
+            logger.error(
+                "Error getting work item field '%s' for input: %r",
+                field,
+                obj,
+            )
+            return "No work item found."
+
+        return getattr(
+            work_item,
+            field,
+            f"Missing field {field} for work item {work_item.id}",
+        )
+
+    @t.overload
+    def render_document(
+        self,
+        template_folder: str | pathlib.Path,
+        template_name: str,
+        polarion_folder: str,
+        polarion_name: str,
+        polarion_type: str | None = None,
+        document_title: str | None = None,
+        heading_numbering: bool = False,  # noqa: FBT002
+        rendering_layouts: list[polarion_api.RenderingLayout] | None = None,
+        *,
+        text_work_item_provider: TextWorkItemProvider | None = None,
+        document_project_id: str | None = None,
+        **kwargs: t.Any,
+    ) -> DocumentData:
+        """Render a new Polarion document."""
+
+    @t.overload
+    def render_document(
+        self,
+        template_folder: str | pathlib.Path,
+        template_name: str,
+        *,
+        document: polarion_api.Document,
+        text_work_item_provider: TextWorkItemProvider | None = None,
+        document_project_id: str | None = None,
+        **kwargs: t.Any,
+    ) -> DocumentData:
+        """Update an existing Polarion document."""
+
+    def render_document(
+        self,
+        template_folder: str | pathlib.Path,
+        template_name: str,
+        polarion_folder: str | None = None,
+        polarion_name: str | None = None,
+        polarion_type: str | None = None,
+        document_title: str | None = None,
+        heading_numbering: bool = False,  # noqa: FBT002
+        rendering_layouts: list[polarion_api.RenderingLayout] | None = None,
+        document: polarion_api.Document | None = None,
+        text_work_item_provider: TextWorkItemProvider | None = None,
+        document_project_id: str | None = None,
+        **kwargs: t.Any,
+    ) -> DocumentData:
+        """Render a Polarion document."""
+        text_work_item_provider = (
+            text_work_item_provider or TextWorkItemProvider()
+        )
+        if document is not None:
+            polarion_folder = document.module_folder
+            polarion_name = document.module_name
+            polarion_type = document.type
+
+        if polarion_name is None or polarion_folder is None:
+            raise AssertionError(
+                "You either need to pass a folder and a name or a document"
+                " with a module_folder and a module_name defined"
+            )
+
+        env = self._get_jinja_env(template_folder)
+        template = env.get_template(template_name)
+
+        session = RenderingSession(
+            document_project_id=document_project_id or self.default_project_id
+        )
+        if document is not None:
+            session.rendering_layouts = document.rendering_layouts or []
+            if document.home_page_content and document.home_page_content.value:
+                session.heading_ids = html_utils.extract_headings(
+                    document.home_page_content.value
+                )
+        else:
+            document = polarion_api.Document(
+                title=document_title,
+                module_folder=polarion_folder,
+                module_name=polarion_name,
+                type=polarion_type,
+                outline_numbering=heading_numbering,
+            )
+            if rendering_layouts is not None:
+                session.rendering_layouts = rendering_layouts
+
+        rendering_result = template.render(
+            **(self.get_template_context() | kwargs | {"session": session})
+        )
+        text_work_item_provider.generate_text_work_items(
+            lxmlhtml.fragments_fromstring(rendering_result),
+        )
+
+        document.home_page_content = polarion_api.TextContent(
+            "text/html",
+            rendering_result,
+        )
+        document.rendering_layouts = session.rendering_layouts
+
+        return DocumentData(
+            document,
+            session.headings,
+            text_work_item_provider,
+        )
+
+    def update_mixed_authority_document(
+        self,
+        document: polarion_api.Document,
+        template_folder: str | pathlib.Path,
+        sections: dict[str, str],
+        global_parameters: dict[str, t.Any],
+        section_parameters: dict[str, dict[str, t.Any]],
+        text_work_item_provider: TextWorkItemProvider | None = None,
+        document_project_id: str | None = None,
+    ) -> DocumentData:
+        """Update a mixed-authority document."""
+        document.type = None
+        text_work_item_provider = (
+            text_work_item_provider or TextWorkItemProvider()
+        )
+        assert document.home_page_content, (
+            "In mixed authority the document must have content"
+        )
+        assert document.home_page_content.value, (
+            "In mixed authority the document must have content"
+        )
+        html_elements = lxmlhtml.fragments_fromstring(
+            document.home_page_content.value
+        )
+
+        session = RenderingSession(
+            rendering_layouts=document.rendering_layouts or [],
+            document_project_id=document_project_id or self.default_project_id,
+        )
+        section_areas = self._extract_section_areas(html_elements, session)
+        env = self._get_jinja_env(template_folder)
+
+        new_content: list[t.Any] = []
+        last_section_end = 0
+
+        for section_name, area in section_areas.items():
+            if section_name not in sections:
+                logger.warning(
+                    "Found section %s in document, but it is not defined in the config",
+                    section_name,
+                )
+                continue
+            new_content += html_elements[last_section_end : area[0] + 1]
+            last_section_end = area[1]
+            current_content = html_elements[area[0] + 1 : area[1]]
+            session.heading_ids = html_utils.extract_headings(current_content)
+            template = env.get_template(sections[section_name])
+            content = template.render(
+                **(
+                    self.get_template_context()
+                    | global_parameters
+                    | section_parameters.get(section_name, {})
+                    | {"session": session}
+                )
+            )
+            work_item_ids = html_utils.extract_work_items(current_content)
+            html_fragments = lxmlhtml.fragments_fromstring(content)
+            text_work_item_provider.generate_text_work_items(
+                html_fragments,
+                work_item_ids,
+            )
+            new_content += html_fragments
+
+        new_content += html_elements[last_section_end:]
+        new_content = html_utils.remove_table_ids(new_content)
+
+        document.home_page_content = polarion_api.TextContent(
+            "text/html",
+            "\n".join(
+                lxmlhtml.tostring(element).decode("utf-8")
+                for element in new_content
+                if not isinstance(element, str)
+            ),
+        )
+        document.rendering_layouts = session.rendering_layouts
+
+        return DocumentData(
+            document,
+            session.headings,
+            text_work_item_provider,
+        )
+
+    def _extract_section_areas(
+        self,
+        html_elements: list[t.Any],
+        session: RenderingSession,
+    ) -> dict[str, tuple[int, int]]:
+        section_areas: dict[str, tuple[int, int]] = {}
+        current_area_id = None
+        current_area_start = None
+        for element_index, element in enumerate(html_elements):
+            assert not isinstance(element, str)
+            if (
+                current_area_id is None
+                and element.tag == "div"
+                and (
+                    wid_match := html_utils.WI_ID_REGEX.match(
+                        element.get("id", "")
+                    )
+                )
+            ):
+                proj_id = (
+                    session.document_project_id or self.default_project_id
+                )
+                if proj_match := html_utils.WI_PROJECT_REGEX.match(
+                    element.get("id", "")
+                ):
+                    proj_id = proj_match.group(1)
+                if proj_id is not None:
+                    session.inserted_work_item_ids.append(
+                        (proj_id, wid_match.group(1))
+                    )
+                continue
+
+            if (
+                element.tag != "div"
+                or element.get("class") != "polarion-dle-wiki-block"
+            ):
+                continue
+            for child in element.iterchildren():
+                if child.get("class") == "polarion-dle-wiki-block-source":
+                    text = html.unescape(child.text or "")
+                    content = lxmlhtml.fragments_fromstring(text)
+                    if (
+                        content
+                        and not isinstance(content[0], str)
+                        and content[0].tag == "div"
+                    ):
+                        element_id = content[0].get("id")
+                        if content[0].get("class") == self.area_start_class:
+                            assert element_id is not None, (
+                                "There was no id set to identify the area"
+                            )
+                            assert current_area_id is None, (
+                                f"Started a new area {element_id} "
+                                f"while being in area {current_area_id}"
+                            )
+                            current_area_id = element_id
+                            current_area_start = element_index
+                        elif content[0].get("class") == self.area_end_class:
+                            assert element_id is not None, (
+                                "There was no id set to identify the area"
+                            )
+                            assert current_area_id == element_id, (
+                                f"Ended area {element_id} "
+                                f"while being in area {current_area_id}"
+                            )
+                            assert current_area_start is not None
+                            assert current_area_id is not None
+                            section_areas[current_area_id] = (
+                                current_area_start,
+                                element_index,
+                            )
+                            current_area_id = None
+                            current_area_start = None
+        return section_areas

--- a/polarion_rest_api_client/document_rendering/document_renderer.py
+++ b/polarion_rest_api_client/document_rendering/document_renderer.py
@@ -11,7 +11,7 @@ import typing as t
 from collections.abc import Mapping
 
 import jinja2
-from lxml import html as lxmlhtml  # type: ignore[import-not-found]
+from lxml import html as lxmlhtml
 
 from polarion_rest_api_client import data_models as polarion_api
 
@@ -341,7 +341,7 @@ class DocumentRenderer:
             **(self.get_template_context() | kwargs | {"session": session})
         )
         text_work_item_provider.generate_text_work_items(
-            lxmlhtml.fragments_fromstring(rendering_result),
+            html_utils.ensure_fragments(rendering_result),
         )
 
         document.home_page_content = polarion_api.TextContent(
@@ -377,7 +377,7 @@ class DocumentRenderer:
         assert document.home_page_content.value, (
             "In mixed authority the document must have content"
         )
-        html_elements = lxmlhtml.fragments_fromstring(
+        html_elements = html_utils.ensure_fragments(
             document.home_page_content.value
         )
 
@@ -412,7 +412,7 @@ class DocumentRenderer:
                 )
             )
             work_item_ids = html_utils.extract_work_items(current_content)
-            html_fragments = lxmlhtml.fragments_fromstring(content)
+            html_fragments = html_utils.ensure_fragments(content)
             text_work_item_provider.generate_text_work_items(
                 html_fragments,
                 work_item_ids,
@@ -478,7 +478,7 @@ class DocumentRenderer:
             for child in element.iterchildren():
                 if child.get("class") == "polarion-dle-wiki-block-source":
                     text = html.unescape(child.text or "")
-                    content = lxmlhtml.fragments_fromstring(text)
+                    content = html_utils.ensure_fragments(text)
                     if (
                         content
                         and not isinstance(content[0], str)

--- a/polarion_rest_api_client/document_rendering/document_renderer.py
+++ b/polarion_rest_api_client/document_rendering/document_renderer.py
@@ -4,25 +4,19 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import html
 import logging
 import pathlib
 import typing as t
-from collections.abc import Mapping
 
 import jinja2
 from lxml import html as lxmlhtml
 
 from polarion_rest_api_client import data_models as polarion_api
 
-from . import html_utils
-from .rendering_session import (
-    DocumentData,
-    RenderingSession,
-    WorkItemLookup,
-    WorkItemLookupResult,
-)
-from .text_work_item_provider import TextWorkItemProvider
+from . import html_utils, rendering_session
+from . import text_work_item_provider as text_work_item_provider_module
 
 PROJ_WI_PAIR_LEN = 2
 
@@ -49,9 +43,9 @@ class DocumentRenderer:
         self,
         default_project_id: str | None = None,
         *,
-        work_item_lookup: WorkItemLookup | None = None,
+        work_item_lookup: rendering_session.WorkItemLookup | None = None,
         work_item_repository: (
-            Mapping[tuple[str, str], polarion_api.WorkItem] | None
+            cabc.Mapping[tuple[str, str], polarion_api.WorkItem] | None
         ) = None,
         area_start_class: str = DEFAULT_AREA_START_CLS,
         area_end_class: str = DEFAULT_AREA_END_CLS,
@@ -93,16 +87,18 @@ class DocumentRenderer:
         return dict(self._extra_template_context)
 
     @t.overload
-    def resolve_work_item(self, obj: object) -> WorkItemLookupResult: ...
+    def resolve_work_item(
+        self, obj: object
+    ) -> rendering_session.WorkItemLookupResult: ...
 
     @t.overload
     def resolve_work_item(
         self, project_id: str, work_item_id: str
-    ) -> WorkItemLookupResult: ...
+    ) -> rendering_session.WorkItemLookupResult: ...
 
     def resolve_work_item(
         self, obj: object, work_item_id: str | None = None
-    ) -> WorkItemLookupResult:
+    ) -> rendering_session.WorkItemLookupResult:
         """Resolve a custom object into a Polarion work item.
 
         The default implementation supports lookups by ``(project_id,
@@ -137,7 +133,7 @@ class DocumentRenderer:
 
     def _resolve_work_item_from_repository(
         self, project_id: str, work_item_id: str
-    ) -> WorkItemLookupResult:
+    ) -> rendering_session.WorkItemLookupResult:
         work_item = self._work_item_repository.get((project_id, work_item_id))
         if work_item is None:
             logger.info(
@@ -148,7 +144,9 @@ class DocumentRenderer:
             return project_id, None
         return project_id, work_item
 
-    def _get_work_item(self, obj: object) -> WorkItemLookupResult:
+    def _get_work_item(
+        self, obj: object
+    ) -> rendering_session.WorkItemLookupResult:
         if isinstance(obj, tuple) and len(obj) == PROJ_WI_PAIR_LEN:
             proj_id, work_item = obj
             if isinstance(proj_id, str) and isinstance(
@@ -174,7 +172,10 @@ class DocumentRenderer:
         return self.resolve_work_item(obj)
 
     def _insert_work_item(
-        self, obj: object, session: RenderingSession, level: int | None = None
+        self,
+        obj: object,
+        session: rendering_session.RenderingSession,
+        level: int | None = None,
     ) -> str:
         proj_id, work_item = self._get_work_item(obj)
 
@@ -229,7 +230,10 @@ class DocumentRenderer:
         return html_utils.RED_TEXT.format(text="Error linking work item.")
 
     def _heading(
-        self, level: int, text: str, session: RenderingSession
+        self,
+        level: int,
+        text: str,
+        session: rendering_session.RenderingSession,
     ) -> str:
         if session.heading_ids:
             hid = session.heading_ids.pop(0)
@@ -265,10 +269,12 @@ class DocumentRenderer:
         heading_numbering: bool = False,  # noqa: FBT002
         rendering_layouts: list[polarion_api.RenderingLayout] | None = None,
         *,
-        text_work_item_provider: TextWorkItemProvider | None = None,
+        text_work_item_provider: (
+            text_work_item_provider_module.TextWorkItemProvider | None
+        ) = None,
         document_project_id: str | None = None,
         **kwargs: t.Any,
-    ) -> DocumentData:
+    ) -> rendering_session.DocumentData:
         """Render a new Polarion document."""
 
     @t.overload
@@ -278,10 +284,12 @@ class DocumentRenderer:
         template_name: str,
         *,
         document: polarion_api.Document,
-        text_work_item_provider: TextWorkItemProvider | None = None,
+        text_work_item_provider: (
+            text_work_item_provider_module.TextWorkItemProvider | None
+        ) = None,
         document_project_id: str | None = None,
         **kwargs: t.Any,
-    ) -> DocumentData:
+    ) -> rendering_session.DocumentData:
         """Update an existing Polarion document."""
 
     def render_document(
@@ -295,13 +303,16 @@ class DocumentRenderer:
         heading_numbering: bool = False,  # noqa: FBT002
         rendering_layouts: list[polarion_api.RenderingLayout] | None = None,
         document: polarion_api.Document | None = None,
-        text_work_item_provider: TextWorkItemProvider | None = None,
+        text_work_item_provider: (
+            text_work_item_provider_module.TextWorkItemProvider | None
+        ) = None,
         document_project_id: str | None = None,
         **kwargs: t.Any,
-    ) -> DocumentData:
+    ) -> rendering_session.DocumentData:
         """Render a Polarion document."""
         text_work_item_provider = (
-            text_work_item_provider or TextWorkItemProvider()
+            text_work_item_provider
+            or text_work_item_provider_module.TextWorkItemProvider()
         )
         if document is not None:
             polarion_folder = document.module_folder
@@ -317,7 +328,7 @@ class DocumentRenderer:
         env = self._get_jinja_env(template_folder)
         template = env.get_template(template_name)
 
-        session = RenderingSession(
+        session = rendering_session.RenderingSession(
             document_project_id=document_project_id or self.default_project_id
         )
         if document is not None:
@@ -350,7 +361,7 @@ class DocumentRenderer:
         )
         document.rendering_layouts = session.rendering_layouts
 
-        return DocumentData(
+        return rendering_session.DocumentData(
             document,
             session.headings,
             text_work_item_provider,
@@ -363,13 +374,16 @@ class DocumentRenderer:
         sections: dict[str, str],
         global_parameters: dict[str, t.Any],
         section_parameters: dict[str, dict[str, t.Any]],
-        text_work_item_provider: TextWorkItemProvider | None = None,
+        text_work_item_provider: (
+            text_work_item_provider_module.TextWorkItemProvider | None
+        ) = None,
         document_project_id: str | None = None,
-    ) -> DocumentData:
+    ) -> rendering_session.DocumentData:
         """Update a mixed-authority document."""
         document.type = None
         text_work_item_provider = (
-            text_work_item_provider or TextWorkItemProvider()
+            text_work_item_provider
+            or text_work_item_provider_module.TextWorkItemProvider()
         )
         assert document.home_page_content, (
             "In mixed authority the document must have content"
@@ -381,7 +395,7 @@ class DocumentRenderer:
             document.home_page_content.value
         )
 
-        session = RenderingSession(
+        session = rendering_session.RenderingSession(
             rendering_layouts=document.rendering_layouts or [],
             document_project_id=document_project_id or self.default_project_id,
         )
@@ -432,7 +446,7 @@ class DocumentRenderer:
         )
         document.rendering_layouts = session.rendering_layouts
 
-        return DocumentData(
+        return rendering_session.DocumentData(
             document,
             session.headings,
             text_work_item_provider,
@@ -441,7 +455,7 @@ class DocumentRenderer:
     def _extract_section_areas(
         self,
         html_elements: list[t.Any],
-        session: RenderingSession,
+        session: rendering_session.RenderingSession,
     ) -> dict[str, tuple[int, int]]:
         section_areas: dict[str, tuple[int, int]] = {}
         current_area_id = None

--- a/polarion_rest_api_client/document_rendering/document_renderer.py
+++ b/polarion_rest_api_client/document_rendering/document_renderer.py
@@ -13,7 +13,7 @@ import typing as t
 import jinja2
 from lxml import html as lxmlhtml
 
-from polarion_rest_api_client import data_models as polarion_api
+from polarion_rest_api_client import data_models
 
 from . import html_utils, rendering_session
 from . import text_work_item_provider as text_work_item_provider_module
@@ -26,6 +26,10 @@ DEFAULT_AREA_END_CLS = "autoRenderAreaEnd"
 """Default marker class for the wiki macro that ends a rendering area."""
 
 logger = logging.getLogger(__name__)
+WorkItemLookupResult = tuple[
+    str | None,
+    data_models.WorkItem | None,
+]
 
 
 class DocumentRenderer:
@@ -43,9 +47,10 @@ class DocumentRenderer:
         self,
         default_project_id: str | None = None,
         *,
-        work_item_lookup: rendering_session.WorkItemLookup | None = None,
+        work_item_lookup: t.Callable[[object], WorkItemLookupResult]
+        | None = None,
         work_item_repository: (
-            cabc.Mapping[tuple[str, str], polarion_api.WorkItem] | None
+            cabc.Mapping[tuple[str, str], data_models.WorkItem] | None
         ) = None,
         area_start_class: str = DEFAULT_AREA_START_CLS,
         area_end_class: str = DEFAULT_AREA_END_CLS,
@@ -87,18 +92,16 @@ class DocumentRenderer:
         return dict(self._extra_template_context)
 
     @t.overload
-    def resolve_work_item(
-        self, obj: object
-    ) -> rendering_session.WorkItemLookupResult: ...
+    def resolve_work_item(self, obj: object) -> WorkItemLookupResult: ...
 
     @t.overload
     def resolve_work_item(
         self, project_id: str, work_item_id: str
-    ) -> rendering_session.WorkItemLookupResult: ...
+    ) -> WorkItemLookupResult: ...
 
     def resolve_work_item(
         self, obj: object, work_item_id: str | None = None
-    ) -> rendering_session.WorkItemLookupResult:
+    ) -> WorkItemLookupResult:
         """Resolve a custom object into a Polarion work item.
 
         The default implementation supports lookups by ``(project_id,
@@ -133,7 +136,7 @@ class DocumentRenderer:
 
     def _resolve_work_item_from_repository(
         self, project_id: str, work_item_id: str
-    ) -> rendering_session.WorkItemLookupResult:
+    ) -> WorkItemLookupResult:
         work_item = self._work_item_repository.get((project_id, work_item_id))
         if work_item is None:
             logger.info(
@@ -144,13 +147,11 @@ class DocumentRenderer:
             return project_id, None
         return project_id, work_item
 
-    def _get_work_item(
-        self, obj: object
-    ) -> rendering_session.WorkItemLookupResult:
+    def _get_work_item(self, obj: object) -> WorkItemLookupResult:
         if isinstance(obj, tuple) and len(obj) == PROJ_WI_PAIR_LEN:
             proj_id, work_item = obj
             if isinstance(proj_id, str) and isinstance(
-                work_item, polarion_api.WorkItem
+                work_item, data_models.WorkItem
             ):
                 if work_item.id:
                     self._work_item_repository[(proj_id, work_item.id)] = (
@@ -237,9 +238,9 @@ class DocumentRenderer:
     ) -> str:
         if session.heading_ids:
             hid = session.heading_ids.pop(0)
-            session.headings.append(polarion_api.WorkItem(id=hid, title=text))
+            session.headings.append(data_models.WorkItem(id=hid, title=text))
             return f'<h{level} id="{html_utils.WI_ID_PREFIX}{hid}"></h{level}>'
-        return f"<h{level}>{text}</h{level}>"
+        return f"<h{level}>{html.escape(text)}</h{level}>"
 
     def _work_item_field(self, obj: object, field: str) -> t.Any:
         _, work_item = self._get_work_item(obj)
@@ -267,7 +268,7 @@ class DocumentRenderer:
         polarion_type: str | None = None,
         document_title: str | None = None,
         heading_numbering: bool = False,  # noqa: FBT002
-        rendering_layouts: list[polarion_api.RenderingLayout] | None = None,
+        rendering_layouts: list[data_models.RenderingLayout] | None = None,
         *,
         text_work_item_provider: (
             text_work_item_provider_module.TextWorkItemProvider | None
@@ -283,7 +284,7 @@ class DocumentRenderer:
         template_folder: str | pathlib.Path,
         template_name: str,
         *,
-        document: polarion_api.Document,
+        document: data_models.Document,
         text_work_item_provider: (
             text_work_item_provider_module.TextWorkItemProvider | None
         ) = None,
@@ -301,8 +302,8 @@ class DocumentRenderer:
         polarion_type: str | None = None,
         document_title: str | None = None,
         heading_numbering: bool = False,  # noqa: FBT002
-        rendering_layouts: list[polarion_api.RenderingLayout] | None = None,
-        document: polarion_api.Document | None = None,
+        rendering_layouts: list[data_models.RenderingLayout] | None = None,
+        document: data_models.Document | None = None,
         text_work_item_provider: (
             text_work_item_provider_module.TextWorkItemProvider | None
         ) = None,
@@ -338,7 +339,7 @@ class DocumentRenderer:
                     document.home_page_content.value
                 )
         else:
-            document = polarion_api.Document(
+            document = data_models.Document(
                 title=document_title,
                 module_folder=polarion_folder,
                 module_name=polarion_name,
@@ -355,7 +356,7 @@ class DocumentRenderer:
             html_utils.ensure_fragments(rendering_result),
         )
 
-        document.home_page_content = polarion_api.TextContent(
+        document.home_page_content = data_models.TextContent(
             "text/html",
             rendering_result,
         )
@@ -369,7 +370,7 @@ class DocumentRenderer:
 
     def update_mixed_authority_document(
         self,
-        document: polarion_api.Document,
+        document: data_models.Document,
         template_folder: str | pathlib.Path,
         sections: dict[str, str],
         global_parameters: dict[str, t.Any],
@@ -436,7 +437,7 @@ class DocumentRenderer:
         new_content += html_elements[last_section_end:]
         new_content = html_utils.remove_table_ids(new_content)
 
-        document.home_page_content = polarion_api.TextContent(
+        document.home_page_content = data_models.TextContent(
             "text/html",
             "\n".join(
                 lxmlhtml.tostring(element).decode("utf-8")

--- a/polarion_rest_api_client/document_rendering/html_utils.py
+++ b/polarion_rest_api_client/document_rendering/html_utils.py
@@ -1,0 +1,160 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Functions for generic Polarion-specific HTML elements."""
+
+from __future__ import annotations
+
+import re
+
+from lxml import html as lxmlhtml  # type: ignore[import-not-found]
+
+from polarion_rest_api_client import data_models as polarion_api
+
+WI_ID_PREFIX = "polarion_wiki macro name=module-workitem;params=id="
+WI_PROJECT_PREFIX = "polarion_wiki macro name=module-workitem;.*project="
+H_REGEX = re.compile("h[0-9]")
+WI_ID_REGEX = re.compile(WI_ID_PREFIX + r"([A-Za-z0-9]*-[0-9]+)")
+WI_PROJECT_REGEX = re.compile(WI_PROJECT_PREFIX + r"([A-Za-z0-9\-_]+)")
+
+TEXT_WORK_ITEM_ID_FIELD = "__C2P__id"
+TEXT_WORK_ITEM_TYPE = "text"
+POLARION_WORK_ITEM_URL = (
+    '<span class="polarion-rte-link" data-type="workItem" '
+    'id="fake" data-item-id="{pid}" data-option-id="long"></span>'
+)
+POLARION_WORK_ITEM_URL_PROJECT = (
+    '<span class="polarion-rte-link" data-type="workItem" '
+    'id="fake" data-scope="{project}" data-item-id="{pid}" '
+    'data-option-id="long"></span>'
+)
+POLARION_WORK_ITEM_DOCUMENT = (
+    '<div id="polarion_wiki macro name=module-workitem;'
+    'params=id={pid}|layout={lid}|{custom_info}external=true"></div>'
+)
+POLARION_WORK_ITEM_DOCUMENT_PROJECT = (
+    '<div id="polarion_wiki macro name=module-workitem;'
+    "params=id={pid}|layout={lid}|{custom_info}external=true"
+    '|project={project}"></div>'
+)
+POLARION_CAPTION = (
+    '<p class="polarion-rte-caption-paragraph">\n  '
+    '{label} <span data-sequence="{label}" '
+    'class="polarion-rte-caption">#</span> {caption}\n</p>'
+)
+RED_TEXT = '<p style="color:red">{text}</p>'
+WORK_ITEM_TAG = "workitem"
+
+
+def strike_through(string: str) -> str:
+    """Return a striked-through HTML span from the given string."""
+    return f'<span style="text-decoration: line-through;">{string}</span>'
+
+
+def generate_image_html(
+    title: str,
+    attachment_id: str,
+    max_width: int,
+    css_class: str,
+    caption: tuple[str, str] | None = None,
+) -> str:
+    """Generate Polarion HTML for an attached image."""
+    description = (
+        f'<span><img title="{title}" class="{css_class}" '
+        f'src="workitemimg:{attachment_id}" '
+        f'style="max-width: {max_width}px;"/></span>'
+    )
+    if caption:
+        description += POLARION_CAPTION.format(
+            label=caption[0], caption=caption[1]
+        )
+    return description
+
+
+def camel_case_to_words(camel_case_str: str) -> str:
+    """Split camel or dromedary case and return a spaced string."""
+    match = re.match(r"^(.*?)(_?[A-Za-z0-9]+)$", camel_case_str)
+    if not match:
+        return camel_case_str
+    prefix, camel_case_part = match.groups()
+    words = re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)", camel_case_part)
+    formatted_words = " ".join(word.capitalize() for word in words)
+    if prefix := prefix.strip("_"):
+        formatted_words += f" ({prefix})"
+    return formatted_words
+
+
+def ensure_fragments(
+    html_content: str | list[lxmlhtml.HtmlElement | str],
+) -> list[lxmlhtml.HtmlElement | str]:
+    """Convert string to html elements."""
+    if isinstance(html_content, str):
+        return lxmlhtml.fragments_fromstring(html_content)
+    return html_content
+
+
+def extract_headings(
+    html_content: str | list[lxmlhtml.HtmlElement | str],
+) -> list[str]:
+    """Return work item IDs for headings."""
+    return extract_work_items(html_content, H_REGEX)
+
+
+def extract_work_items(
+    html_content: str | list[lxmlhtml.HtmlElement | str],
+    tag_regex: re.Pattern[str] | None = None,
+) -> list[str]:
+    """Return work item IDs from content."""
+    work_item_ids: list[str] = []
+    html_fragments = ensure_fragments(html_content)
+    for element in html_fragments:
+        if not isinstance(element, lxmlhtml.HtmlElement):
+            continue
+        tag_name = element.tag
+        if not isinstance(tag_name, str):
+            continue
+        if (tag_regex is not None and tag_regex.fullmatch(tag_name)) or (
+            tag_regex is None and tag_name == "div"
+        ):
+            elmid = element.get("id")
+            if elmid is not None and (matches := WI_ID_REGEX.match(elmid)):
+                work_item_ids.append(matches.group(1))
+    return work_item_ids
+
+
+def get_layout_index(
+    default_layouter: str,
+    rendering_layouts: list[polarion_api.RenderingLayout],
+    work_item_type: str,
+) -> int:
+    """Return the index of layout for work item."""
+    layout_index = 0
+    for layout in rendering_layouts:
+        if layout.type == work_item_type:
+            return layout_index
+        layout_index += 1
+    if layout_index >= len(rendering_layouts):
+        rendering_layouts.append(
+            polarion_api.RenderingLayout(
+                type=work_item_type,
+                layouter=default_layouter,
+                label=camel_case_to_words(work_item_type),
+            )
+        )
+    return layout_index
+
+
+def remove_table_ids(
+    html_content: str | list[lxmlhtml.HtmlElement | str],
+) -> list[lxmlhtml.HtmlElement | str]:
+    """Remove the ID field from all tables.
+
+    This works around a Polarion limitation where duplicate table IDs in
+    document HTML are rejected by the REST API.
+    """
+    html_fragments = ensure_fragments(html_content)
+    for element in html_fragments:
+        if not isinstance(element, lxmlhtml.HtmlElement):
+            continue
+        if element.tag == "table":
+            element.attrib.pop("id", None)
+    return html_fragments

--- a/polarion_rest_api_client/document_rendering/html_utils.py
+++ b/polarion_rest_api_client/document_rendering/html_utils.py
@@ -18,7 +18,7 @@ H_REGEX = re.compile("h[0-9]")
 WI_ID_REGEX = re.compile(WI_ID_PREFIX + r"([A-Za-z0-9]*-[0-9]+)")
 WI_PROJECT_REGEX = re.compile(WI_PROJECT_PREFIX + r"([A-Za-z0-9\-_]+)")
 
-TEXT_WORK_ITEM_ID_FIELD = "__C2P__id"
+TEXT_WORK_ITEM_ID_FIELD = "__AUTO_RENDER__id"
 TEXT_WORK_ITEM_TYPE = "text"
 POLARION_WORK_ITEM_URL = (
     '<span class="polarion-rte-link" data-type="workItem" '

--- a/polarion_rest_api_client/document_rendering/html_utils.py
+++ b/polarion_rest_api_client/document_rendering/html_utils.py
@@ -5,16 +5,16 @@
 from __future__ import annotations
 
 import collections.abc as cabc
+import html
 import re
-import typing as t
 
 from lxml import html as lxmlhtml
 
-from polarion_rest_api_client import data_models as polarion_api
+from polarion_rest_api_client import data_models
 
 WI_ID_PREFIX = "polarion_wiki macro name=module-workitem;params=id="
 WI_PROJECT_PREFIX = "polarion_wiki macro name=module-workitem;.*project="
-H_REGEX = re.compile("h[0-9]")
+H_REGEX = re.compile("h[0-9]+")
 WI_ID_REGEX = re.compile(WI_ID_PREFIX + r"([A-Za-z0-9]*-[0-9]+)")
 WI_PROJECT_REGEX = re.compile(WI_PROJECT_PREFIX + r"([A-Za-z0-9\-_]+)")
 
@@ -50,7 +50,11 @@ type HtmlFragment = lxmlhtml.HtmlElement | str
 
 def strike_through(string: str) -> str:
     """Return a striked-through HTML span from the given string."""
-    return f'<span style="text-decoration: line-through;">{string}</span>'
+    return (
+        '<span style="text-decoration: line-through;">'
+        f"{html.escape(string)}"
+        "</span>"
+    )
 
 
 def generate_image_html(
@@ -61,14 +65,16 @@ def generate_image_html(
     caption: tuple[str, str] | None = None,
 ) -> str:
     """Generate Polarion HTML for an attached image."""
+    escaped_title = html.escape(title)
     description = (
-        f'<span><img title="{title}" class="{css_class}" '
+        f'<span><img title="{escaped_title}" class="{css_class}" '
         f'src="workitemimg:{attachment_id}" '
         f'style="max-width: {max_width}px;"/></span>'
     )
     if caption:
         description += POLARION_CAPTION.format(
-            label=caption[0], caption=caption[1]
+            label=html.escape(caption[0]),
+            caption=html.escape(caption[1]),
         )
     return description
 
@@ -91,10 +97,7 @@ def ensure_fragments(
 ) -> list[HtmlFragment]:
     """Convert string to html elements."""
     if isinstance(html_content, str):
-        return t.cast(
-            list[HtmlFragment],
-            lxmlhtml.fragments_fromstring(html_content),
-        )
+        return lxmlhtml.fragments_fromstring(html_content)
     return list(html_content)
 
 
@@ -129,7 +132,7 @@ def extract_work_items(
 
 def get_layout_index(
     default_layouter: str,
-    rendering_layouts: list[polarion_api.RenderingLayout],
+    rendering_layouts: list[data_models.RenderingLayout],
     work_item_type: str,
 ) -> int:
     """Return the index of layout for work item."""
@@ -140,7 +143,7 @@ def get_layout_index(
         layout_index += 1
     if layout_index >= len(rendering_layouts):
         rendering_layouts.append(
-            polarion_api.RenderingLayout(
+            data_models.RenderingLayout(
                 type=work_item_type,
                 layouter=default_layouter,
                 label=camel_case_to_words(work_item_type),

--- a/polarion_rest_api_client/document_rendering/html_utils.py
+++ b/polarion_rest_api_client/document_rendering/html_utils.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import re
+import typing as t
 
-from lxml import html as lxmlhtml  # type: ignore[import-not-found]
+from lxml import html as lxmlhtml
 
 from polarion_rest_api_client import data_models as polarion_api
 
@@ -43,6 +45,7 @@ POLARION_CAPTION = (
 )
 RED_TEXT = '<p style="color:red">{text}</p>'
 WORK_ITEM_TAG = "workitem"
+type HtmlFragment = lxmlhtml.HtmlElement | str
 
 
 def strike_through(string: str) -> str:
@@ -84,23 +87,26 @@ def camel_case_to_words(camel_case_str: str) -> str:
 
 
 def ensure_fragments(
-    html_content: str | list[lxmlhtml.HtmlElement | str],
-) -> list[lxmlhtml.HtmlElement | str]:
+    html_content: str | cabc.Sequence[HtmlFragment],
+) -> list[HtmlFragment]:
     """Convert string to html elements."""
     if isinstance(html_content, str):
-        return lxmlhtml.fragments_fromstring(html_content)
-    return html_content
+        return t.cast(
+            list[HtmlFragment],
+            lxmlhtml.fragments_fromstring(html_content),
+        )
+    return list(html_content)
 
 
 def extract_headings(
-    html_content: str | list[lxmlhtml.HtmlElement | str],
+    html_content: str | cabc.Sequence[HtmlFragment],
 ) -> list[str]:
     """Return work item IDs for headings."""
     return extract_work_items(html_content, H_REGEX)
 
 
 def extract_work_items(
-    html_content: str | list[lxmlhtml.HtmlElement | str],
+    html_content: str | cabc.Sequence[HtmlFragment],
     tag_regex: re.Pattern[str] | None = None,
 ) -> list[str]:
     """Return work item IDs from content."""
@@ -144,8 +150,8 @@ def get_layout_index(
 
 
 def remove_table_ids(
-    html_content: str | list[lxmlhtml.HtmlElement | str],
-) -> list[lxmlhtml.HtmlElement | str]:
+    html_content: str | cabc.Sequence[HtmlFragment],
+) -> list[HtmlFragment]:
     """Remove the ID field from all tables.
 
     This works around a Polarion limitation where duplicate table IDs in

--- a/polarion_rest_api_client/document_rendering/rendering_session.py
+++ b/polarion_rest_api_client/document_rendering/rendering_session.py
@@ -10,8 +10,8 @@ import typing as t
 from polarion_rest_api_client import data_models as polarion_api
 
 if t.TYPE_CHECKING:
-    from polarion_rest_api_client.document_rendering.text_work_item_provider import (
-        TextWorkItemProvider,
+    from polarion_rest_api_client.document_rendering import (
+        text_work_item_provider,
     )
 
 WorkItemLookupResult = tuple[
@@ -47,4 +47,4 @@ class DocumentData:
 
     document: polarion_api.Document
     headings: list[polarion_api.WorkItem]
-    text_work_item_provider: TextWorkItemProvider
+    text_work_item_provider: text_work_item_provider.TextWorkItemProvider

--- a/polarion_rest_api_client/document_rendering/rendering_session.py
+++ b/polarion_rest_api_client/document_rendering/rendering_session.py
@@ -7,18 +7,12 @@ from __future__ import annotations
 import dataclasses
 import typing as t
 
-from polarion_rest_api_client import data_models as polarion_api
+from polarion_rest_api_client import data_models
 
 if t.TYPE_CHECKING:
     from polarion_rest_api_client.document_rendering import (
         text_work_item_provider,
     )
-
-WorkItemLookupResult = tuple[
-    str | None,
-    polarion_api.WorkItem | None,
-]
-WorkItemLookup = t.Callable[[object], WorkItemLookupResult]
 
 
 @dataclasses.dataclass
@@ -26,17 +20,17 @@ class RenderingSession:
     """A data class for parameters handled during a rendering session."""
 
     document_project_id: str | None
-    headings: list[polarion_api.WorkItem] = dataclasses.field(
+    headings: list[data_models.WorkItem] = dataclasses.field(
         default_factory=list
     )
     heading_ids: list[str] = dataclasses.field(default_factory=list)
-    rendering_layouts: list[polarion_api.RenderingLayout] = dataclasses.field(
+    rendering_layouts: list[data_models.RenderingLayout] = dataclasses.field(
         default_factory=list
     )
     inserted_work_item_ids: list[tuple[str, str]] = dataclasses.field(
         default_factory=list
     )
-    text_work_items: dict[str, polarion_api.WorkItem] = dataclasses.field(
+    text_work_items: dict[str, data_models.WorkItem] = dataclasses.field(
         default_factory=dict
     )
 
@@ -45,6 +39,6 @@ class RenderingSession:
 class DocumentData:
     """A rendered Polarion document together with companion metadata."""
 
-    document: polarion_api.Document
-    headings: list[polarion_api.WorkItem]
+    document: data_models.Document
+    headings: list[data_models.WorkItem]
     text_work_item_provider: text_work_item_provider.TextWorkItemProvider

--- a/polarion_rest_api_client/document_rendering/rendering_session.py
+++ b/polarion_rest_api_client/document_rendering/rendering_session.py
@@ -1,0 +1,50 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Shared data structures for document rendering."""
+
+from __future__ import annotations
+
+import dataclasses
+import typing as t
+
+from polarion_rest_api_client import data_models as polarion_api
+
+if t.TYPE_CHECKING:
+    from polarion_rest_api_client.document_rendering.text_work_item_provider import (
+        TextWorkItemProvider,
+    )
+
+WorkItemLookupResult = tuple[
+    str | None,
+    polarion_api.WorkItem | None,
+]
+WorkItemLookup = t.Callable[[object], WorkItemLookupResult]
+
+
+@dataclasses.dataclass
+class RenderingSession:
+    """A data class for parameters handled during a rendering session."""
+
+    document_project_id: str | None
+    headings: list[polarion_api.WorkItem] = dataclasses.field(
+        default_factory=list
+    )
+    heading_ids: list[str] = dataclasses.field(default_factory=list)
+    rendering_layouts: list[polarion_api.RenderingLayout] = dataclasses.field(
+        default_factory=list
+    )
+    inserted_work_item_ids: list[tuple[str, str]] = dataclasses.field(
+        default_factory=list
+    )
+    text_work_items: dict[str, polarion_api.WorkItem] = dataclasses.field(
+        default_factory=dict
+    )
+
+
+@dataclasses.dataclass
+class DocumentData:
+    """A rendered Polarion document together with companion metadata."""
+
+    document: polarion_api.Document
+    headings: list[polarion_api.WorkItem]
+    text_work_item_provider: TextWorkItemProvider

--- a/polarion_rest_api_client/document_rendering/text_work_item_provider.py
+++ b/polarion_rest_api_client/document_rendering/text_work_item_provider.py
@@ -1,0 +1,153 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Provides a class to generate and insert text work items in documents."""
+
+from lxml import html
+
+from polarion_rest_api_client import data_models as polarion_api
+
+from . import html_utils
+
+
+class TextWorkItemProvider:
+    """Class providing text work items, their generation and insertion."""
+
+    def __init__(
+        self,
+        text_work_item_id_field: str = html_utils.TEXT_WORK_ITEM_ID_FIELD,
+        text_work_item_type: str = html_utils.TEXT_WORK_ITEM_TYPE,
+        existing_text_work_items: list[polarion_api.WorkItem] | None = None,
+    ) -> None:
+        """Initialize the text work item provider.
+
+        Parameters
+        ----------
+        text_work_item_id_field
+            The field name for custom IDs on text work items.
+        text_work_item_type
+            The type name for text work items.
+        existing_text_work_items
+            Existing text work items to reuse.
+        """
+        self.old_text_work_items: dict[str, polarion_api.WorkItem] = {}
+        for work_item in existing_text_work_items or []:
+            if text_id := work_item.additional_attributes.get(
+                text_work_item_id_field
+            ):
+                if text_id in self.old_text_work_items:
+                    raise ValueError(
+                        f"Multiple text work items with "
+                        f"{text_work_item_id_field} == {text_id}"
+                    )
+                self.old_text_work_items[text_id] = work_item
+
+        self.text_work_item_id_field = text_work_item_id_field
+        self.text_work_item_type = text_work_item_type
+        self.new_text_work_items: dict[str, polarion_api.WorkItem] = {}
+
+    def generate_text_work_items(
+        self,
+        content: list[html.HtmlElement | str],
+        work_item_id_filter: list[str] | None = None,
+    ) -> None:
+        """Generate text work items from the provided html.
+
+        Parameters
+        ----------
+        content
+            HTML content to extract work items from.
+        work_item_id_filter
+            Only generate work items with these IDs.
+        """
+        content = html_utils.ensure_fragments(content)
+        for element in content:
+            if isinstance(element, str):
+                continue
+            if element.tag != html_utils.WORK_ITEM_TAG:
+                continue
+
+            if not (text_id := element.get("id")):
+                raise ValueError("All work items must have an ID")
+
+            if not (
+                (work_item := self.old_text_work_items.get(text_id))
+                and (
+                    work_item_id_filter is None
+                    or work_item.id in work_item_id_filter
+                )
+            ):
+                work_item = polarion_api.WorkItem(
+                    type=self.text_work_item_type,
+                    title="",
+                    status="open",
+                    additional_attributes={
+                        self.text_work_item_id_field: text_id
+                    },
+                )
+
+            inner_content = "".join(
+                [
+                    (
+                        html.tostring(child, encoding="unicode")
+                        if isinstance(child, html.HtmlElement)
+                        else child
+                    )
+                    for child in element.iterchildren()
+                ]
+            )
+            if element.text:
+                inner_content = element.text + inner_content
+
+            work_item.description = polarion_api.HtmlContent(inner_content)
+            self.new_text_work_items[text_id] = work_item
+
+    def insert_text_work_items(
+        self,
+        document: polarion_api.Document,
+    ) -> None:
+        """Insert text work items into the given document.
+
+        Parameters
+        ----------
+        document
+            The document to insert work items into.
+        """
+        if not self.new_text_work_items:
+            return
+
+        assert document.home_page_content is not None
+        assert document.rendering_layouts is not None
+        layout_index = html_utils.get_layout_index(
+            "paragraph", document.rendering_layouts, self.text_work_item_type
+        )
+        html_fragments = html_utils.ensure_fragments(
+            document.home_page_content.value or ""
+        )
+        new_content: list[html.HtmlElement | str] = []
+        last_match = -1
+        for index, element in enumerate(html_fragments):
+            if not isinstance(element, html.HtmlElement):
+                continue
+
+            if element.tag == html_utils.WORK_ITEM_TAG:
+                new_content.extend(html_fragments[last_match + 1 : index])
+                last_match = index
+                if work_item := self.new_text_work_items.get(
+                    element.get("id", "")
+                ):
+                    new_content.append(
+                        html.fromstring(
+                            html_utils.POLARION_WORK_ITEM_DOCUMENT.format(
+                                pid=work_item.id,
+                                lid=layout_index,
+                                custom_info="",
+                            )
+                        )
+                    )
+
+        new_content += html_fragments[last_match + 1 :]
+        document.home_page_content.value = "\n".join(
+            html.tostring(element).decode("utf-8")
+            for element in new_content
+            if isinstance(element, html.HtmlElement)
+        )

--- a/polarion_rest_api_client/document_rendering/text_work_item_provider.py
+++ b/polarion_rest_api_client/document_rendering/text_work_item_provider.py
@@ -4,7 +4,7 @@
 
 from lxml import html as lxmlhtml
 
-from polarion_rest_api_client import data_models as polarion_api
+from polarion_rest_api_client import data_models
 
 from . import html_utils
 
@@ -16,7 +16,7 @@ class TextWorkItemProvider:
         self,
         text_work_item_id_field: str = html_utils.TEXT_WORK_ITEM_ID_FIELD,
         text_work_item_type: str = html_utils.TEXT_WORK_ITEM_TYPE,
-        existing_text_work_items: list[polarion_api.WorkItem] | None = None,
+        existing_text_work_items: list[data_models.WorkItem] | None = None,
     ) -> None:
         """Initialize the text work item provider.
 
@@ -29,7 +29,7 @@ class TextWorkItemProvider:
         existing_text_work_items
             Existing text work items to reuse.
         """
-        self.old_text_work_items: dict[str, polarion_api.WorkItem] = {}
+        self.old_text_work_items: dict[str, data_models.WorkItem] = {}
         for work_item in existing_text_work_items or []:
             if text_id := work_item.additional_attributes.get(
                 text_work_item_id_field
@@ -43,7 +43,7 @@ class TextWorkItemProvider:
 
         self.text_work_item_id_field = text_work_item_id_field
         self.text_work_item_type = text_work_item_type
-        self.new_text_work_items: dict[str, polarion_api.WorkItem] = {}
+        self.new_text_work_items: dict[str, data_models.WorkItem] = {}
 
     def generate_text_work_items(
         self,
@@ -76,7 +76,7 @@ class TextWorkItemProvider:
                     or work_item.id in work_item_id_filter
                 )
             ):
-                work_item = polarion_api.WorkItem(
+                work_item = data_models.WorkItem(
                     type=self.text_work_item_type,
                     title="",
                     status="open",
@@ -98,12 +98,12 @@ class TextWorkItemProvider:
             if element.text:
                 inner_content = element.text + inner_content
 
-            work_item.description = polarion_api.HtmlContent(inner_content)
+            work_item.description = data_models.HtmlContent(inner_content)
             self.new_text_work_items[text_id] = work_item
 
     def insert_text_work_items(
         self,
-        document: polarion_api.Document,
+        document: data_models.Document,
     ) -> None:
         """Insert text work items into the given document.
 

--- a/polarion_rest_api_client/document_rendering/text_work_item_provider.py
+++ b/polarion_rest_api_client/document_rendering/text_work_item_provider.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Provides a class to generate and insert text work items in documents."""
 
-from lxml import html
+from lxml import html as lxmlhtml
 
 from polarion_rest_api_client import data_models as polarion_api
 
@@ -47,7 +47,7 @@ class TextWorkItemProvider:
 
     def generate_text_work_items(
         self,
-        content: list[html.HtmlElement | str],
+        content: list[lxmlhtml.HtmlElement | str],
         work_item_id_filter: list[str] | None = None,
     ) -> None:
         """Generate text work items from the provided html.
@@ -88,8 +88,8 @@ class TextWorkItemProvider:
             inner_content = "".join(
                 [
                     (
-                        html.tostring(child, encoding="unicode")
-                        if isinstance(child, html.HtmlElement)
+                        lxmlhtml.tostring(child, encoding="unicode")
+                        if isinstance(child, lxmlhtml.HtmlElement)
                         else child
                     )
                     for child in element.iterchildren()
@@ -123,10 +123,10 @@ class TextWorkItemProvider:
         html_fragments = html_utils.ensure_fragments(
             document.home_page_content.value or ""
         )
-        new_content: list[html.HtmlElement | str] = []
+        new_content: list[lxmlhtml.HtmlElement | str] = []
         last_match = -1
         for index, element in enumerate(html_fragments):
-            if not isinstance(element, html.HtmlElement):
+            if not isinstance(element, lxmlhtml.HtmlElement):
                 continue
 
             if element.tag == html_utils.WORK_ITEM_TAG:
@@ -136,7 +136,7 @@ class TextWorkItemProvider:
                     element.get("id", "")
                 ):
                     new_content.append(
-                        html.fromstring(
+                        lxmlhtml.fromstring(
                             html_utils.POLARION_WORK_ITEM_DOCUMENT.format(
                                 pid=work_item.id,
                                 lid=layout_index,
@@ -147,7 +147,7 @@ class TextWorkItemProvider:
 
         new_content += html_fragments[last_match + 1 :]
         document.home_page_content.value = "\n".join(
-            html.tostring(element).decode("utf-8")
+            lxmlhtml.tostring(element).decode("utf-8")
             for element in new_content
-            if isinstance(element, html.HtmlElement)
+            if isinstance(element, lxmlhtml.HtmlElement)
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
   "httpx>=0.20.0,<0.29.0",
   "attrs>=21.3.0",
+  "lxml>=5.3.0",
   "python-dateutil>=2.8.0",
   "truststore>=0.10.1",
 ]
@@ -49,6 +50,7 @@ tests = [
 dev = [
   {include-group = "tests"},
   "codespell==2.4.1",
+  "lxml-stubs>=0.5.1",
   "mypy==1.16.1",
   "openapi-python-client==0.25.1",
   "pre-commit>=4.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
   "httpx>=0.20.0,<0.29.0",
   "attrs>=21.3.0",
+  "jinja2>=3.1.0",
   "lxml>=5.3.0",
   "python-dateutil>=2.8.0",
   "truststore>=0.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ tests = [
 dev = [
   {include-group = "tests"},
   "codespell==2.4.1",
-  "lxml-stubs>=0.5.1",
+  "types-lxml>=2026.2.16",
   "mypy==1.16.1",
   "openapi-python-client==0.25.1",
   "pre-commit>=4.2.0",

--- a/tests/test_document_rendering.py
+++ b/tests/test_document_rendering.py
@@ -179,7 +179,12 @@ def test_render_document_generates_text_work_items(tmp_path):
 
     work_item = rendered.text_work_item_provider.new_text_work_items["txt-1"]
     assert work_item.type == "text"
-    assert work_item.additional_attributes["__C2P__id"] == "txt-1"
+    assert (
+        work_item.additional_attributes[
+            document_rendering.TEXT_WORK_ITEM_ID_FIELD
+        ]
+        == "txt-1"
+    )
     assert work_item.description is not None
     assert work_item.description.value == "<p>Hello</p>"
 

--- a/tests/test_document_rendering.py
+++ b/tests/test_document_rendering.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import textwrap
 
-from lxml import html  # type: ignore[import-not-found]
+from lxml import html as lxmlhtml
 
 import polarion_rest_api_client as polarion_api
 from polarion_rest_api_client import document_rendering
@@ -37,7 +37,7 @@ def test_render_document_with_tuple_work_item(tmp_path):
         item=item,
     )
 
-    content = html.fragments_fromstring(
+    content = lxmlhtml.fragments_fromstring(
         rendered.document.home_page_content.value
     )
 
@@ -79,7 +79,7 @@ def test_render_document_with_work_item_id_lookup(tmp_path):
         item_id="REQ-2",
     )
 
-    content = html.fragments_fromstring(
+    content = lxmlhtml.fragments_fromstring(
         rendered.document.home_page_content.value
     )
     assert content[0].tag == "div"
@@ -118,7 +118,7 @@ def test_render_document_falls_back_to_callback_lookup(tmp_path):
         custom_obj={"source": "custom"},
     )
 
-    content = html.fragments_fromstring(
+    content = lxmlhtml.fragments_fromstring(
         rendered.document.home_page_content.value
     )
     assert content[0].tag == "div"
@@ -223,7 +223,7 @@ def test_update_mixed_authority_document_reuses_heading_ids(tmp_path):
         {},
     )
 
-    content = html.fragments_fromstring(
+    content = lxmlhtml.fragments_fromstring(
         rendered.document.home_page_content.value
     )
 

--- a/tests/test_document_rendering.py
+++ b/tests/test_document_rendering.py
@@ -89,6 +89,30 @@ def test_render_document_with_work_item_id_lookup(tmp_path):
     )
 
 
+def test_render_document_escapes_heading_text(tmp_path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "doc.j2").write_text(
+        "{{ heading(1, 'Main <Heading> & \"Title\"', session) }}",
+        encoding="utf-8",
+    )
+
+    renderer = document_rendering.DocumentRenderer(default_project_id="PRJ")
+    rendered = renderer.render_document(
+        template_dir,
+        "doc.j2",
+        "_default",
+        "DOC-ESCAPE",
+    )
+
+    assert rendered.document.home_page_content is not None
+    assert rendered.document.home_page_content.value is not None
+    assert (
+        rendered.document.home_page_content.value.strip()
+        == "<h1>Main &lt;Heading&gt; &amp; &quot;Title&quot;</h1>"
+    )
+
+
 def test_render_document_falls_back_to_callback_lookup(tmp_path):
     template_dir = tmp_path / "templates"
     template_dir.mkdir()

--- a/tests/test_document_rendering.py
+++ b/tests/test_document_rendering.py
@@ -1,0 +1,239 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import logging
+import textwrap
+
+from lxml import html  # type: ignore[import-not-found]
+
+import polarion_rest_api_client as polarion_api
+from polarion_rest_api_client import document_rendering
+
+
+def test_render_document_with_tuple_work_item(tmp_path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "doc.j2").write_text(
+        textwrap.dedent(
+            """\
+            {{ heading(1, "Main Heading", session) }}
+            {{ insert_work_item(item, session) }}
+            <p>{{ item | link_work_item }}</p>
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    renderer = document_rendering.DocumentRenderer(default_project_id="PRJ")
+    item = ("PRJ", polarion_api.WorkItem(id="REQ-1", type="requirement"))
+
+    rendered = renderer.render_document(
+        template_dir,
+        "doc.j2",
+        "_default",
+        "DOC-1",
+        document_title="My Doc",
+        item=item,
+    )
+
+    content = html.fragments_fromstring(
+        rendered.document.home_page_content.value
+    )
+
+    assert rendered.document.title == "My Doc"
+    assert len(rendered.document.rendering_layouts) == 1
+    assert rendered.document.rendering_layouts[0].type == "requirement"
+    assert content[0].tag == "h1"
+    assert content[0].text == "Main Heading"
+    assert content[1].tag == "div"
+    assert content[1].get("id") == (
+        "polarion_wiki macro name=module-workitem;"
+        "params=id=REQ-1|layout=0|external=true"
+    )
+    assert content[2][0].attrib["data-scope"] == "PRJ"
+
+
+def test_render_document_with_work_item_id_lookup(tmp_path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "doc.j2").write_text(
+        "{{ insert_work_item(item_id, session) }}",
+        encoding="utf-8",
+    )
+
+    renderer = document_rendering.DocumentRenderer(
+        default_project_id="PRJ",
+        work_item_repository={
+            ("PRJ", "REQ-2"): polarion_api.WorkItem(
+                id="REQ-2", type="requirement"
+            )
+        },
+    )
+
+    rendered = renderer.render_document(
+        template_dir,
+        "doc.j2",
+        "_default",
+        "DOC-LOOKUP",
+        item_id="REQ-2",
+    )
+
+    content = html.fragments_fromstring(
+        rendered.document.home_page_content.value
+    )
+    assert content[0].tag == "div"
+    assert content[0].get("id") == (
+        "polarion_wiki macro name=module-workitem;"
+        "params=id=REQ-2|layout=0|external=true"
+    )
+
+
+def test_render_document_falls_back_to_callback_lookup(tmp_path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "doc.j2").write_text(
+        "{{ insert_work_item(custom_obj, session) }}",
+        encoding="utf-8",
+    )
+
+    def lookup(obj: object):
+        if obj == {"source": "custom"}:
+            return (
+                "PRJ",
+                polarion_api.WorkItem(id="REQ-3", type="requirement"),
+            )
+        return None, None
+
+    renderer = document_rendering.DocumentRenderer(
+        default_project_id="PRJ",
+        work_item_lookup=lookup,
+    )
+
+    rendered = renderer.render_document(
+        template_dir,
+        "doc.j2",
+        "_default",
+        "DOC-CALLBACK",
+        custom_obj={"source": "custom"},
+    )
+
+    content = html.fragments_fromstring(
+        rendered.document.home_page_content.value
+    )
+    assert content[0].tag == "div"
+    assert content[0].get("id") == (
+        "polarion_wiki macro name=module-workitem;"
+        "params=id=REQ-3|layout=0|external=true"
+    )
+
+
+def test_render_document_logs_info_for_missing_repository_item(
+    tmp_path, caplog
+):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "doc.j2").write_text(
+        "{{ insert_work_item(item_id, session) }}",
+        encoding="utf-8",
+    )
+
+    renderer = document_rendering.DocumentRenderer(default_project_id="PRJ")
+
+    with caplog.at_level(logging.INFO):
+        rendered = renderer.render_document(
+            template_dir,
+            "doc.j2",
+            "_default",
+            "DOC-MISSING",
+            item_id="REQ-404",
+        )
+
+    assert (
+        "WorkItem PRJ/REQ-404 was not found in the renderer lookup repository."
+        in caplog.text
+    )
+    assert rendered.document.home_page_content is not None
+    assert (
+        "Error inserting work item"
+        in rendered.document.home_page_content.value
+    )
+
+
+def test_render_document_generates_text_work_items(tmp_path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "doc.j2").write_text(
+        '<workitem id="txt-1"><p>Hello</p></workitem>',
+        encoding="utf-8",
+    )
+
+    renderer = document_rendering.DocumentRenderer(default_project_id="PRJ")
+
+    rendered = renderer.render_document(
+        template_dir,
+        "doc.j2",
+        "_default",
+        "DOC-2",
+    )
+
+    work_item = rendered.text_work_item_provider.new_text_work_items["txt-1"]
+    assert work_item.type == "text"
+    assert work_item.additional_attributes["__C2P__id"] == "txt-1"
+    assert work_item.description is not None
+    assert work_item.description.value == "<p>Hello</p>"
+
+
+def test_update_mixed_authority_document_reuses_heading_ids(tmp_path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "section.j2").write_text(
+        '{{ heading(2, "Updated Heading", session) }}<p>{{ message }}</p>',
+        encoding="utf-8",
+    )
+
+    old_document = polarion_api.Document(
+        module_folder="_default",
+        module_name="DOC-3",
+        home_page_content=polarion_api.TextContent(
+            type="text/html",
+            value=textwrap.dedent(
+                """\
+                <p>Before</p>
+                <div class="polarion-dle-wiki-block">
+                  <div class="polarion-dle-wiki-block-source">&lt;div class=&quot;autoRenderAreaStart&quot; id=&quot;section1&quot;&gt;&lt;/div&gt;</div>
+                </div>
+                <h2 id="polarion_wiki macro name=module-workitem;params=id=REQ-9"></h2>
+                <p>Old content</p>
+                <div class="polarion-dle-wiki-block">
+                  <div class="polarion-dle-wiki-block-source">&lt;div class=&quot;autoRenderAreaEnd&quot; id=&quot;section1&quot;&gt;&lt;/div&gt;</div>
+                </div>
+                <p>After</p>
+                """
+            ),
+        ),
+    )
+
+    renderer = document_rendering.DocumentRenderer(default_project_id="PRJ")
+    rendered = renderer.update_mixed_authority_document(
+        old_document,
+        template_dir,
+        {"section1": "section.j2"},
+        {"message": "New content"},
+        {},
+    )
+
+    content = html.fragments_fromstring(
+        rendered.document.home_page_content.value
+    )
+
+    assert content[0].text == "Before"
+    assert content[2].tag == "h2"
+    assert content[2].get("id") == (
+        "polarion_wiki macro name=module-workitem;params=id=REQ-9"
+    )
+    assert content[3].text == "New content"
+    assert content[-1].text == "After"
+    assert len(rendered.headings) == 1
+    assert rendered.headings[0].id == "REQ-9"
+    assert rendered.headings[0].title == "Updated Heading"

--- a/tests/test_html_utils.py
+++ b/tests/test_html_utils.py
@@ -1,0 +1,81 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from lxml import html
+
+from polarion_rest_api_client import data_models as polarion_api
+from polarion_rest_api_client.document_rendering import html_utils
+
+
+def test_strike_through_wraps_text():
+    rendered = html_utils.strike_through("removed")
+    assert rendered == (
+        '<span style="text-decoration: line-through;">removed</span>'
+    )
+
+
+def test_generate_image_html_with_caption():
+    rendered = html_utils.generate_image_html(
+        title="Architecture",
+        attachment_id="arch.svg",
+        max_width=640,
+        css_class="diagram",
+        caption=("Figure", "Logical architecture"),
+    )
+
+    fragments = html.fragments_fromstring(rendered)
+    assert fragments[0].tag == "span"
+    assert fragments[0][0].tag == "img"
+    assert fragments[0][0].attrib["src"] == "workitemimg:arch.svg"
+    assert fragments[1].tag == "p"
+    assert "Logical architecture" in fragments[1].text_content()
+
+
+def test_extract_headings_and_work_items():
+    rendered = "".join(
+        [
+            '<h1 id="polarion_wiki macro name=module-workitem;params=id=REQ-1"></h1>',
+            '<div id="polarion_wiki macro name=module-workitem;params=id=REQ-2"></div>',
+        ]
+    )
+
+    assert html_utils.extract_headings(rendered) == ["REQ-1"]
+    assert html_utils.extract_work_items(rendered) == ["REQ-2"]
+
+
+def test_get_layout_index_returns_existing_layout():
+    layouts = [
+        polarion_api.RenderingLayout(type="requirement", layouter="section")
+    ]
+
+    idx = html_utils.get_layout_index("section", layouts, "requirement")
+
+    assert idx == 0
+    assert len(layouts) == 1
+
+
+def test_get_layout_index_appends_layout_if_missing():
+    layouts: list[polarion_api.RenderingLayout] = []
+
+    idx = html_utils.get_layout_index("section", layouts, "systemFunction")
+
+    assert idx == 0
+    assert len(layouts) == 1
+    assert layouts[0].type == "systemFunction"
+    assert layouts[0].label == "System Function"
+
+
+def test_remove_table_ids_only_changes_tables():
+    fragments = html_utils.remove_table_ids(
+        '<table id="a"><tr><td>v</td></tr></table><div id="keep"></div>'
+    )
+
+    table = fragments[0]
+    div = fragments[1]
+    assert not isinstance(table, str)
+    assert not isinstance(div, str)
+    assert table.tag == "table"
+    assert "id" not in table.attrib
+    assert div.attrib["id"] == "keep"

--- a/tests/test_html_utils.py
+++ b/tests/test_html_utils.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from lxml import html
+from lxml import html as lxmlhtml
 
 from polarion_rest_api_client import data_models as polarion_api
 from polarion_rest_api_client.document_rendering import html_utils
@@ -25,7 +25,7 @@ def test_generate_image_html_with_caption():
         caption=("Figure", "Logical architecture"),
     )
 
-    fragments = html.fragments_fromstring(rendered)
+    fragments = lxmlhtml.fragments_fromstring(rendered)
     assert fragments[0].tag == "span"
     assert fragments[0][0].tag == "img"
     assert fragments[0][0].attrib["src"] == "workitemimg:arch.svg"

--- a/tests/test_html_utils.py
+++ b/tests/test_html_utils.py
@@ -5,32 +5,37 @@ from __future__ import annotations
 
 from lxml import html as lxmlhtml
 
-from polarion_rest_api_client import data_models as polarion_api
+from polarion_rest_api_client import data_models
 from polarion_rest_api_client.document_rendering import html_utils
 
 
 def test_strike_through_wraps_text():
-    rendered = html_utils.strike_through("removed")
+    rendered = html_utils.strike_through("removed <danger>")
     assert rendered == (
-        '<span style="text-decoration: line-through;">removed</span>'
+        '<span style="text-decoration: line-through;">'
+        "removed &lt;danger&gt;"
+        "</span>"
     )
 
 
 def test_generate_image_html_with_caption():
     rendered = html_utils.generate_image_html(
-        title="Architecture",
-        attachment_id="arch.svg",
+        title='Architecture "v2"',
+        attachment_id="arch&.svg",
         max_width=640,
-        css_class="diagram",
-        caption=("Figure", "Logical architecture"),
+        css_class="diagram main",
+        caption=("Figure <A>", "Logical architecture & dependencies"),
     )
 
     fragments = lxmlhtml.fragments_fromstring(rendered)
     assert fragments[0].tag == "span"
     assert fragments[0][0].tag == "img"
-    assert fragments[0][0].attrib["src"] == "workitemimg:arch.svg"
+    assert fragments[0][0].attrib["title"] == 'Architecture "v2"'
+    assert fragments[0][0].attrib["src"] == "workitemimg:arch&.svg"
     assert fragments[1].tag == "p"
-    assert "Logical architecture" in fragments[1].text_content()
+    caption_text = "".join(fragments[1].itertext())
+    assert "Figure <A>" in caption_text
+    assert "Logical architecture & dependencies" in caption_text
 
 
 def test_extract_headings_and_work_items():
@@ -47,7 +52,7 @@ def test_extract_headings_and_work_items():
 
 def test_get_layout_index_returns_existing_layout():
     layouts = [
-        polarion_api.RenderingLayout(type="requirement", layouter="section")
+        data_models.RenderingLayout(type="requirement", layouter="section")
     ]
 
     idx = html_utils.get_layout_index("section", layouts, "requirement")
@@ -57,7 +62,7 @@ def test_get_layout_index_returns_existing_layout():
 
 
 def test_get_layout_index_appends_layout_if_missing():
-    layouts: list[polarion_api.RenderingLayout] = []
+    layouts: list[data_models.RenderingLayout] = []
 
     idx = html_utils.get_layout_index("section", layouts, "systemFunction")
 


### PR DESCRIPTION
- Adds a new `document_rendering` API for rendering Polarion documents from Jinja templates.
- Introduces `DocumentRenderer` to create new documents and update existing ones from template output.
- Supports work item resolution by explicit `(project_id, WorkItem)` tuples, `(project_id, work_item_id)`, plain `work_item_id` (via default project), and custom lookup callbacks.
- Provides template helpers for inserting/linking work items, heading generation, and field access in rendered content.
- Supports mixed-authority updates by replacing only configured section areas inside an existing document while preserving surrounding content.
- Adds `TextWorkItemProvider` to convert `<workitem id="...">` placeholders into Polarion text work items and reinject them into document HTML.
- Adds shared HTML utilities for Polarion-specific markup handling (fragment parsing, heading/work-item extraction, layout selection, image/caption markup, table-id cleanup).
- Adds documentation/examples for rendering workflows, including mixed-authority document rendering.